### PR TITLE
add: mythen role and module

### DIFF
--- a/roles/admythen/README.md
+++ b/roles/admythen/README.md
@@ -1,0 +1,3 @@
+# admythen
+
+Ansible role for deploying admythen IOC instances.

--- a/roles/admythen/example.yml
+++ b/roles/admythen/example.yml
@@ -1,0 +1,12 @@
+---
+
+admythen-01:
+  type: admythen
+  environment:
+    ENGINEER: C. Engineer
+    PREFIX: XF:31ID1-ES{ADMYTHEN:01}
+    MYTHEN_IP: 192.168.0.90
+    MYTHEN_IP_PORT: 1031
+    XSIZE: 1280 # No Y-size for Mythen
+    PORT: MSD1
+    IP_PORT: MDS1_IP

--- a/roles/admythen/schema.yml
+++ b/roles/admythen/schema.yml
@@ -6,16 +6,15 @@ environment:
   PREFIX: str()
   MYTHEN_IP: any(ip(), hostname())
   MYTHEN_IP_PORT: int(min=1, max=65535)
-  XSIZE: int(min=1, required=false)
+  XSIZE: int(min=1, default=1280)
   PORT: str()
   IP_PORT: str()
 
   # Optional overrides
-  QSIZE: int(min=1, required=false)
+  QSIZE: int(min=1, default=20, required=False)
   # Mythen has no Y-size, but keep for compatibility
-  YSIZE: enum(1, required=false)
-  NCHANS: int(min=1, required=false)
-  CBUFFS: int(min=1, required=false)
-  MAX_THREADS: int(min=1, required=false)
-  EPICS_DB_INCLUDE_PATH: str(required=false)
-  NELEMENTS: int(min=1, required=false)
+  YSIZE: enum(1, default=1, required=False)
+  NCHANS: int(min=1, default=1280, required=False)
+  CBUFFS: int(min=1, default=100, required=False)
+  MAX_THREADS: int(min=1, default=8, required=False)
+  NELEMENTS: int(min=1, default=5000000,required=False)

--- a/roles/admythen/schema.yml
+++ b/roles/admythen/schema.yml
@@ -1,0 +1,21 @@
+---
+
+type: enum("admythen")
+environment:
+  ENGINEER: str()
+  PREFIX: str()
+  MYTHEN_IP: any(ip(), hostname())
+  MYTHEN_IP_PORT: int(min=1, max=65535)
+  XSIZE: int(min=1, required=false)
+  PORT: str()
+  IP_PORT: str()
+
+  # Optional overrides
+  QSIZE: int(min=1, required=false)
+  # Mythen has no Y-size, but keep for compatibility
+  YSIZE: enum(1, required=false)
+  NCHANS: int(min=1, required=false)
+  CBUFFS: int(min=1, required=false)
+  MAX_THREADS: int(min=1, required=false)
+  EPICS_DB_INCLUDE_PATH: str(required=false)
+  NELEMENTS: int(min=1, required=false)

--- a/roles/admythen/tasks/main.yml
+++ b/roles/admythen/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# Tasks for admythen role
+
+- name: Copy base.cmd
+  ansible.builtin.template:
+    src: "templates/base.cmd.j2"
+    dest: "{{ deploy_ioc_ioc_directory }}/iocBoot/base.cmd"
+    owner: "{{ host_info_softioc_user }}"
+    group: "{{ host_info_softioc_group }}"
+    mode: "0664"
+
+- name: Copy autosave req file
+  ansible.builtin.template:
+    src: "templates/auto_settings.req.j2"
+    dest: "{{ deploy_ioc_ioc_directory }}/autosave/req/auto_settings.req"
+    owner: "{{ host_info_softioc_user }}"
+    group: "{{ host_info_softioc_group }}"
+    mode: "0664"

--- a/roles/admythen/templates/auto_settings.req.j2
+++ b/roles/admythen/templates/auto_settings.req.j2
@@ -1,0 +1,6 @@
+file "ADBase_settings.req",         P=$(P),  R=cam1:
+file "NDFile_settings.req",         P=$(P),  R=cam1:
+file "mythen_settings.req",       P=$(P),  R=cam1:
+file "NDPluginBase_settings.req",   P=$(P),  R=image1:
+file "NDStdArrays_settings.req",    P=$(P),  R=image1:
+file "commonPlugin_settings.req",   P=$(P)

--- a/roles/admythen/templates/base.cmd.j2
+++ b/roles/admythen/templates/base.cmd.j2
@@ -1,0 +1,18 @@
+
+dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable }}.dbd")
+{{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)
+
+# admythen specific commands
+drvAsynIPPortConfigure("$(IP_PORT_NAME)", "$(MYTHEN_IP):(MYTHEN_IP_PORT)", 0, 0, 1)
+
+asynOctetSetInputEos("$(IP_PORT_NAME)",0,"\r\n")
+asynOctetSetOutputEos("$(IP_PORT_NAME)",0,"\r")
+
+mythenConfig("$(PORT)", "$(IP_PORT_NAME)", -1,-1)
+
+dbLoadRecords("$(ADMYTHEN)/mythenApp/Db/mythen.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
+
+# Load asynRecord records on Mythen communication
+dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(PREFIX),R=asyn_1,PORT=IP_M1K,ADDR=0,OMAX=256,IMAX=256")
+
+set_requestfile_path("$(TOP)/mythenApp/Db")

--- a/roles/admythen/templates/base.cmd.j2
+++ b/roles/admythen/templates/base.cmd.j2
@@ -3,7 +3,7 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 {{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)
 
 # admythen specific commands
-drvAsynIPPortConfigure("$(IP_PORT_NAME)", "$(MYTHEN_IP):(MYTHEN_IP_PORT)", 0, 0, 1)
+drvAsynIPPortConfigure("$(IP_PORT_NAME)", "$(MYTHEN_IP):$(MYTHEN_IP_PORT)", 0, 0, 1)
 
 asynOctetSetInputEos("$(IP_PORT_NAME)",0,"\r\n")
 asynOctetSetOutputEos("$(IP_PORT_NAME)",0,"\r")
@@ -13,6 +13,6 @@ mythenConfig("$(PORT)", "$(IP_PORT_NAME)", -1,-1)
 dbLoadRecords("$(ADMYTHEN)/mythenApp/Db/mythen.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
 
 # Load asynRecord records on Mythen communication
-dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(PREFIX),R=asyn_1,PORT=IP_M1K,ADDR=0,OMAX=256,IMAX=256")
+dbLoadRecords("$(ASYN)/db/asynRecord.db", "P=$(PREFIX),R=asyn_1,PORT=$(IP_PORT_NAME),ADDR=0,OMAX=256,IMAX=256")
 
 set_requestfile_path("$(TOP)/mythenApp/Db")

--- a/roles/deploy_ioc/vars/admythen.yml
+++ b/roles/deploy_ioc/vars/admythen.yml
@@ -1,0 +1,24 @@
+---
+
+deploy_ioc_use_common: true
+deploy_ioc_use_ad_common: true
+deploy_ioc_required_module: admythen_bcf2947
+deploy_ioc_executable: mythenApp
+deploy_ioc_as_dir_name: autosave
+deploy_ioc_template_root_path:
+  "{{ deploy_ioc_required_module_path }}/iocs/mythenIOC"
+
+deploy_ioc_device_specific_env:
+  ADMYTHEN: "/epics/modules/ADMythen"
+  MYTHEN_IP: 192.168.0.90
+  MYTHEN_IP_PORT: 1031
+  IP_PORT_NAME: "MDS1_IP"
+  PORT: "MSD1"
+  QSIZE: 20
+  XSIZE: 1280
+  YSIZE: 1
+  NCHANS: 1280
+  CBUFFS: 100
+  MAX_THREADS: 8
+  EPICS_DB_INCLUDE_PATH: "$(ADCORE)/db:$(ADMYTHEN)/db"
+  NELEMENTS: 5000000

--- a/roles/install_module/vars/admythen_bcf2947.yml
+++ b/roles/install_module/vars/admythen_bcf2947.yml
@@ -1,0 +1,12 @@
+---
+
+admythen_bcf2947:
+  name: ADMythen
+  version: bcf2947
+  url: https://github.com/areaDetector/ADMythen
+  include_base_ad_config: true
+  module_deps:
+    - adcore_60080dc
+    - adcompvision_9750d13
+    - adpluginbar_448d96b
+    - ffmpeg_server_07c570f

--- a/roles/install_module/vars/admythen_bcf2947.yml
+++ b/roles/install_module/vars/admythen_bcf2947.yml
@@ -1,7 +1,7 @@
 ---
 
 admythen_bcf2947:
-  name: ADMythen
+  name: admythen
   version: bcf2947
   url: https://github.com/areaDetector/ADMythen
   include_base_ad_config: true


### PR DESCRIPTION
## Requires Review:

- [ ] Broke up MYTHEN_IP_PORT and IP_PORT (looked like a cname), to MYTHEN_IP (IP), MYTHEN_IP_PORT (int), and IP_PORT_NAME (str)
- [ ] Does the auto_settings.req.j2 need any conditionals?
- [ ] Kept YSIZE as a locked enum, but Mythen doesn't have a Y dimension. Should it be removed?
- [ ] Sanity check the dependencies in the added install_module/vars/admythen_bcf2947.yml.
