### PR TITLE
add: ad-eiger

### DIFF
--- a/roles/adeiger/README.md
+++ b/roles/adeiger/README.md
@@ -1,0 +1,3 @@
+# adeiger
+
+Ansible role for deploying adeiger IOC instances.

--- a/roles/adeiger/example.yml
+++ b/roles/adeiger/example.yml
@@ -13,7 +13,7 @@ adeiger-01:
   environment:
     ENGINEER: C. Engineer
     PREFIX: XF:31ID1-ES{ADEIGER:01}
-    EIGERIP: "10.69.57.71"
+    EIGER_IP: "10.69.57.71"
     ADEIGER: "/epics/modules/ADEiger_R3_4"
 
     XSIZE: 1030

--- a/roles/adeiger/example.yml
+++ b/roles/adeiger/example.yml
@@ -1,0 +1,26 @@
+---
+
+adeiger-01:
+  type: adeiger
+  # Eiger version must be 1 for Eiger or 2 for Eiger2
+  eiger_version: enum(1, 2)
+
+  # Configure local port if Eiger is connected directly to the server.
+  # Comment out otherwise.
+  # adeiger_local_intf_mac: "98:b7:85:01:4a:dd"
+  # adeiger_local_intf_ip: "192.168.0.1"
+
+  environment:
+    ENGINEER: C. Engineer
+    PREFIX: XF:31ID1-ES{ADEIGER:01}
+    EIGERIP: "10.69.57.71"
+    ADEIGER: "/epics/modules/ADEiger_R3_4"
+
+    XSIZE: 1030
+    YSIZE: 1065
+
+    QSIZE: 2048
+
+    # The maximum number of frames buffered in the NDPluginCircularBuff plugin
+    CBUFFS: 8192
+    NELEMENTS: 1096950

--- a/roles/adeiger/example.yml
+++ b/roles/adeiger/example.yml
@@ -3,7 +3,7 @@
 adeiger-01:
   type: adeiger
   # Eiger version must be 1 for Eiger or 2 for Eiger2
-  eiger_version: enum(1, 2)
+  eiger_version: 1
 
   # Configure local port if Eiger is connected directly to the server.
   # Comment out otherwise.

--- a/roles/adeiger/example.yml
+++ b/roles/adeiger/example.yml
@@ -14,7 +14,6 @@ adeiger-01:
     ENGINEER: C. Engineer
     PREFIX: XF:31ID1-ES{ADEIGER:01}
     EIGER_IP: "10.69.57.71"
-    ADEIGER: "/epics/modules/ADEiger_R3_4"
 
     XSIZE: 1030
     YSIZE: 1065

--- a/roles/adeiger/schema.yml
+++ b/roles/adeiger/schema.yml
@@ -1,0 +1,25 @@
+---
+
+type: enum("adeiger")
+# Eiger version must be 1 for Eiger or 2 for Eiger2
+eiger_version: enum(1, 2)
+
+# Configure local port if Eiger is connected directly to the server.
+# Comment out otherwise.
+adeiger_local_inf_mac: str(required=False)
+adeiger_local_intf_ip: any(ip(), hostname(), required=False)
+
+environment:
+  ENGINEER: str()
+  PREFIX: str()
+  EIGERIP: any(ip(), hostname())
+  STREAMIP: any(ip(), hostname(), required=False)
+  ADEIGER: str()
+
+  XSIZE: int()
+  YSIZE: int()
+  QSIZE: int()
+
+  # The maximum number of frames buffered in the NDPluginCircularBuff plugin
+  CBUFFS: int()
+  NELEMENTS: int()

--- a/roles/adeiger/schema.yml
+++ b/roles/adeiger/schema.yml
@@ -12,7 +12,7 @@ adeiger_local_intf_ip: any(ip(), hostname(), required=False)
 environment:
   ENGINEER: str()
   PREFIX: str()
-  EIGERIP: any(ip(), hostname())
+  EIGER_IP: any(ip(), hostname())
   STREAMIP: any(ip(), hostname(), required=False)
   ADEIGER: str()
 

--- a/roles/adeiger/schema.yml
+++ b/roles/adeiger/schema.yml
@@ -14,7 +14,6 @@ environment:
   PREFIX: str()
   EIGER_IP: any(ip(), hostname())
   STREAMIP: any(ip(), hostname(), required=False)
-  ADEIGER: str()
 
   XSIZE: int()
   YSIZE: int()

--- a/roles/adeiger/tasks/main.yml
+++ b/roles/adeiger/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Tasks for adeiger role
+
+- name: Copy base.cmd
+  ansible.builtin.template:
+    src: "templates/base.cmd.j2"
+    dest: "{{ deploy_ioc_ioc_directory }}/iocBoot/base.cmd"
+    owner: "{{ host_info_softioc_user }}"
+    group: "{{ host_info_softioc_group }}"
+    mode: "0664"
+
+- name: Configure local interface on target server if specified
+  when:
+    - ioc.adeiger_local_intf_mac is defined
+    - ioc.adeiger_local_intf_ip is defined
+  block:
+    - name: Prepare parameters
+      ansible.builtin.set_fact:
+        _local_mac: "{{ ioc.adeiger_local_intf_mac }}"
+        _local_ip: "{{ ioc.adeiger_local_intf_ip }}"
+        _local_netmask: "255.255.255.192"
+
+    - name: Ensure that MAC does not collide with SCI/CAM/INST interfaces
+      ansible.builtin.include_tasks: "validate_local_intf.yml"
+
+    - name: Print selected parameters
+      ansible.builtin.debug:
+        msg:
+          MAC: "{{ _local_mac }}"
+          IP: "{{ _local_ip }}"
+          NETMASK: "{{ _local_netmask }}"
+          MTU: "{{ _local_intf_mtu }}"
+          INTERFACE: "{{ _local_intf }}"
+
+    - name: Add config file for processing scripts
+      ansible.builtin.template:
+        src: templates/ifcfg-interface.sh.j2
+        dest: "/etc/sysconfig/network-scripts/ifcfg-{{ _local_intf }}"
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Restart NetworkManager
+      ansible.builtin.service:
+        name: NetworkManager
+        state: restarted

--- a/roles/adeiger/tasks/validate_local_intf.yml
+++ b/roles/adeiger/tasks/validate_local_intf.yml
@@ -1,0 +1,65 @@
+---
+
+- name: Set SCIENCE interface facts
+  ansible.builtin.set_fact:
+    sci_interface: "{{ ansible_default_ipv4.interface }}"
+    sci_address: "{{ ansible_default_ipv4.address }}"
+    _local_intf_mtu:
+      "{{ ansible_facts[ansible_default_ipv4.interface]['mtu'] }}"
+    sci_mac:
+      "{{ ansible_facts[ansible_default_ipv4.interface]['macaddress'] }}"
+
+
+- name: Select which interface (device) to configure
+  block:
+    - name: Find interface based on MAC address
+      ansible.builtin.set_fact:
+        _local_intf: "{{ item }}"
+      with_items: "{{ ansible_facts['interfaces'] }}"
+      when: >
+        "macaddress" in ansible_facts[item] and
+        (ansible_facts[item]['macaddress'] | lower)==(_local_mac | lower)
+
+    - name: Check if the interface with the MAC address was found
+      ansible.builtin.assert:
+        that:
+          - _local_intf is defined
+        msg:
+          "The interface with MAC address {{ _local_mac }} was not found"
+
+    - name: Verify that we are not attempting to reconfigure the SCI interface
+      ansible.builtin.assert:
+        that:
+          - (_local_mac | lower)!=(sci_mac | lower)
+        msg: MAC {{ _local_mac }} belongs to the SCIENCE interface
+
+    - name: Verify that we are not attempting to reconfigure the CAM interface
+      ansible.builtin.assert:
+        that:
+          - (network_macaddress_cam is undefined) or (_local_mac | lower)!=
+            (network_macaddress_cam | lower)
+        msg: MAC {{ _local_mac }} belongs to the CAM interface
+
+    - name: Verify that we are not attempting to reconfigure the INST interface
+      ansible.builtin.assert:
+        that:
+          - (network_macaddress_inst is undefined) or ((_local_mac | lower)!=
+            (network_macaddress_inst | lower))
+        msg: MAC {{ _local_mac }} belongs to the INST interface
+
+    - name: Print the selected interface
+      ansible.builtin.debug:
+        var: _local_intf
+
+- name: Adjust MTU for 10G network unless MTU was explicitly specified
+  block:
+    - name: Get Link Speed for the selected interface
+      ansible.builtin.command:
+        "cat /sys/class/net/{{ _local_intf }}/speed"
+      register: link_speed
+      changed_when: true
+
+    - name: Adjust MTU if necessary
+      ansible.builtin.set_fact:
+        _local_intf_mtu: 9000
+      when: link_speed.stdout|int > 1000

--- a/roles/adeiger/templates/base.cmd.j2
+++ b/roles/adeiger/templates/base.cmd.j2
@@ -1,0 +1,17 @@
+
+dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable }}.dbd")
+{{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)
+
+# adeiger specific commands
+errlogInit(20000)
+
+{% if ioc.environment.STREAMIP is defined %}
+eigerDetectorConfig("$(PORT)", "$(EIGERIP)", "$(STREAMIP)", 0, 0)
+{% else %}
+eigerDetectorConfig("$(PORT)", "$(EIGERIP)", 0, 0)
+{% endif %}
+dbLoadRecords("$(ADEIGER)/db/eiger{{ ioc.eiger_version }}.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
+
+
+# Debug
+#asynSetTraceMask("$(PORT)", 0, 0x11)

--- a/roles/adeiger/templates/base.cmd.j2
+++ b/roles/adeiger/templates/base.cmd.j2
@@ -6,9 +6,9 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 errlogInit(20000)
 
 {% if ioc.environment.STREAMIP is defined %}
-eigerDetectorConfig("$(PORT)", "$(EIGERIP)", "$(STREAMIP)", 0, 0)
+eigerDetectorConfig("$(PORT)", "$(EIGER_IP)", "$(STREAMIP)", 0, 0)
 {% else %}
-eigerDetectorConfig("$(PORT)", "$(EIGERIP)", 0, 0)
+eigerDetectorConfig("$(PORT)", "$(EIGER_IP)", 0, 0)
 {% endif %}
 dbLoadRecords("$(ADEIGER)/db/eiger{{ ioc.eiger_version }}.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
 

--- a/roles/deploy_ioc/vars/adeiger.yml
+++ b/roles/deploy_ioc/vars/adeiger.yml
@@ -1,0 +1,20 @@
+---
+
+deploy_ioc_use_common: true
+deploy_ioc_use_ad_common: true
+deploy_ioc_required_module: adeiger_05e8a65
+deploy_ioc_executable: eigerDetectorApp
+deploy_ioc_as_dir_name: autosave
+deploy_ioc_template_root_path:
+  "{{ deploy_ioc_required_module_path }}/iocs/eigerIOC"
+
+deploy_ioc_device_specific_env:
+  PORT: "EIG"
+  QSIZE: 20
+  XSIZE: 1030
+  YSIZE: 1065
+  NCHANS: 2048
+  CBUFFS: 500
+  MAX_THREADS: 8
+  EPICS_DB_INCLUDE_PATH: "$(ADCORE)/db:$(ADEIGER)/db"
+  NELEMENTS: 1096950


### PR DESCRIPTION
## Requires Review

- [ ] Scrubbed NELMT, EPICS_CA_MAX_ARRAY_BYTES, all for NELEMENTS
- [ ] Dropped this block from base.cmd

```
# Create a standard arrays plugin
NDStdArraysConfigure("Image1", 5, 0, "$(PORT)", 0, 0)
dbLoadRecords("$(ADCORE)/db/NDStdArrays.template", "P=$(PREFIX),R=image1:,PORT=Image1,ADDR=0,TIMEOUT=1,TYPE=Int32,FTVL=LONG,NELEMENTS=1096950, NDARRAY_PORT=$(PORT)")

NDStdArraysConfigure("Image2", 5, 0, "$(PORT)", 1, 0)
dbLoadRecords("$(ADCORE)/db/NDStdArrays.template", "P=$(PREFIX),R=image2:,PORT=Image2,ADDR=0,TIMEOUT=1,TYPE=Int32,FTVL=LONG,NELEMENTS=1096950, NDARRAY_PORT=$(PORT)")

# Additional records for the IOC
dbLoadRecords("$(DEVIOCSTATS)/db/iocAdminSoft.db", "IOC=$(PREFIX)")
dbLoadRecords("$(AUTOSAVE)/db/save_restoreStatus.db", "P=$(PREFIX)")

# Load all other plugins using commonPlugins.cmd
< $(ADCORE)/iocBoot/commonPlugins.cmd

< ./AutoSave.cmd
```