### PR TITLE
fix: host var naming and erroneous copy

### DIFF
--- a/roles/admerlin/tasks/main.yml
+++ b/roles/admerlin/tasks/main.yml
@@ -6,8 +6,8 @@
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: "{{ deploy_ioc_ioc_directory }}/iocBoot"
-    owner: "{{ softioc_user }}"
-    group: "{{ softioc_group }}"
+    owner: "{{ host_info_softioc_user }}"
+    group: "{{ host_info_softioc_group }}"
     mode: "0664"
   with_fileglob: "files/*.cmd"
 
@@ -15,16 +15,8 @@
   ansible.builtin.template:
     src: "templates/base.cmd.j2"
     dest: "{{ deploy_ioc_ioc_directory }}/iocBoot/base.cmd"
-    owner: "{{ softioc_user }}"
-    group: "{{ softioc_group }}"
-    mode: "0664"
-
-- name: Copy autosave req file
-  ansible.builtin.copy:
-    src: "files/auto_settings.req"
-    dest: "{{ deploy_ioc_ioc_directory }}/autosave/req/auto_settings.req"
-    owner: "{{ softioc_user }}"
-    group: "{{ softioc_group }}"
+    owner: "{{ host_info_softioc_user }}"
+    group: "{{ host_info_softioc_group }}"
     mode: "0664"
 
 - name: Configure local interface on target server if specified


### PR DESCRIPTION
I caught these mistakes while doing other dev/review.