### PR TITLE
Remove explicit ansible lint workflow from CI - it is already covered…

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -52,40 +52,6 @@ jobs:
           files: |
             **/*.{yml,yaml}
 
-  run_ansible_lint:
-    name: Run ansible-lint
-    runs-on: ubuntu-latest
-    needs: [get_changed_files]
-    if: needs.get_changed_files.outputs.any_changed == 'true'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      - name: Install python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.9'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ansible-core==2.14.1 ansible-lint
-
-      - name: Install ansible galaxy requirements
-        run: |
-          ansible-galaxy install -r collections/requirements.yml --timeout 120
-
-      - name: Lint playbook
-        run: |
-          # shellcheck disable=SC2086
-          ansible-lint -c .ansible-lint --offline \
-            --exclude roles/install_module/vars/* \
-            ${NEEDS_GET_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES}
-        env:
-          NEEDS_GET_CHANGED_FILES_OUTPUTS_ALL_CHANGED_FILES: ${{ needs.get_changed_files.outputs.all_changed_files }} # yamllint disable-line rule:line-length
-
   run_pre_commit:
     name: Run pre-commit hooks
     runs-on: ubuntu-latest


### PR DESCRIPTION
… by running pre-commit

This should also get rid of the annoying github actions warning message that was showing up in every PR review.