### PR TITLE
Add .pixi/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dev_install.sh
 __pycache__/
 *.pyc
 .ansible/
+.pixi/


### PR DESCRIPTION
Also, we should think about using detached environments so we don't install these environments on network drives