### PR TITLE
Fix regex pattern for macro identification

### DIFF
--- a/roles/deploy_ioc/tasks/process-env.yml
+++ b/roles/deploy_ioc/tasks/process-env.yml
@@ -7,7 +7,7 @@
 - name: Identify macros in envvar value
   ansible.builtin.set_fact:
     deploy_ioc_macros_in_var: "{{ deploy_ioc_merged_env[item] |
-                        regex_findall('\\$\\([A-Za-z_][A-Za-z0-9_]*\\)') }}"
+                        regex_findall('\\$\\(([A-Za-z_][A-Za-z0-9_]*)\\)') }}"
 
 - name: Show macros found in var
   ansible.builtin.debug:


### PR DESCRIPTION
It is currently capturing the surrounding `$(` and `)` when it should filter them out.