### PR TITLE
Fix issue where newline was being added to executable name

### DIFF
--- a/roles/install_module/tasks/install-module.yml
+++ b/roles/install_module/tasks/install-module.yml
@@ -157,6 +157,6 @@
 
 - name: If specified, set installed leaf module executable
   ansible.builtin.set_fact:
-    install_module_leaf_executable: >
-      {{ install_module_config.executable }}
+    install_module_leaf_executable:
+      "{{ install_module_config.executable }}"
   when: install_module_config.executable is defined


### PR DESCRIPTION
```diff
-dbLoadDatabase("/epics/modules/advimba_34686fe/iocs/vimbaIOC/dbd/vimbaApp
-.dbd")
-vimbaApp
-_registerRecordDeviceDriver(pdbbase)
+dbLoadDatabase("/epics/modules/advimba_34686fe/iocs/vimbaIOC/dbd/vimbaApp.dbd")
+vimbaApp_registerRecordDeviceDriver(pdbbase)
```

Found when deploying the new camera at CDI. This small typo was adding a newline after the executable name.