### PR TITLE
Fix dubious ownership errors in install_module role

### DIFF
--- a/roles/install_module/tasks/install-module.yml
+++ b/roles/install_module/tasks/install-module.yml
@@ -25,11 +25,21 @@
         path: "{{ install_module_dir }}/.git"
       register: install_module_cloned
 
+    - name: Check if module directory is already in git safe.directory
+      ansible.builtin.command:
+        "git config --global --get-all safe.directory" # noqa command-instead-of-module
+      become: true
+      become_user: "{{ host_config.softioc_user }}"
+      register: install_module_safe_dirs
+      changed_when: false
+      failed_when: false
+
     - name: Add module directory to git safe.directory list
       ansible.builtin.command:
         "git config --global --add safe.directory {{ install_module_dir }}" # noqa command-instead-of-module
       become: true
       become_user: "{{ host_config.softioc_user }}"
+      when: install_module_dir not in (install_module_safe_dirs.stdout_lines | default([]))
       changed_when: true
 
     # The only changes should be to CONFIG_SITE and RELEASE files,
@@ -103,13 +113,25 @@
 
 # base is a special case, because it is cloned recursively, and should not
 # have any release/configure files adjusted.
+- name: Check if epics_base directory is already in git safe.directory
+  ansible.builtin.command:
+    "git config --global --get-all safe.directory" # noqa command-instead-of-module
+  become: true
+  become_user: "{{ host_config.softioc_user }}"
+  register: install_module_base_safe_dirs
+  changed_when: false
+  failed_when: false
+  when: install_module_name.startswith("epics_base")
+
 - name: Add epics_base directory to git safe.directory list
   ansible.builtin.command:
     "git config --global --add safe.directory {{ install_module_dir }}" # noqa command-instead-of-module
   become: true
   become_user: "{{ host_config.softioc_user }}"
   changed_when: true
-  when: install_module_name.startswith("epics_base")
+  when: >-
+    install_module_name.startswith("epics_base") and
+    install_module_dir not in (install_module_base_safe_dirs.stdout_lines | default([]))
 
 - name: Handle epics_base
   ansible.builtin.git:


### PR DESCRIPTION
## Summary
- Replace pre-git `ansible.builtin.file` chown with `git config --global --add safe.directory` as `softioc_user` before git operations, fixing the "dubious ownership" error on re-deploys where modules were originally cloned as root
- Add the same `safe.directory` config for `epics_base` clones
- Move ownership enforcement (`chown -R`) to after compilation so files are properly owned by `softioc_user` at the end

## Test plan
- [ ] Deploy to a host that has existing modules cloned by root — verify no "dubious ownership" error
- [ ] Deploy to a fresh host — verify clone, compile, and ownership all succeed
- [ ] Re-deploy to the same host — verify stash and checkout work without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)