### PR TITLE
Fix container deployment: ensure softioc user home directory exists

### DIFF
--- a/roles/install_module/tasks/install-module.yml
+++ b/roles/install_module/tasks/install-module.yml
@@ -16,6 +16,19 @@
     state: "directory"
     mode: "0775"
 
+- name: Look up softioc user home directory
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ host_config.softioc_user }}"
+
+- name: Ensure softioc user home directory exists
+  ansible.builtin.file:
+    path: "{{ getent_passwd[host_config.softioc_user][4] }}"
+    owner: "{{ host_config.softioc_user }}"
+    group: "{{ host_config.softioc_group }}"
+    state: directory
+    mode: "0755"
+
 - name: Handle standard module
   when: not install_module_name.startswith("epics_base")
   block:


### PR DESCRIPTION
## Summary
- Fixes the container deployment failure reported in #186
- Adds two tasks to `install_module` that look up the softioc user's home directory via `getent` and create it if missing, before any `git config --global` commands run

## Problem
After PR #183 was merged, deploying IOCs in a container fails at the `Add module directory to git safe.directory list` task:

```
fatal: [nsls2_ioc_deploy_el8]: FAILED! => {"changed": true, "cmd": ["git", "config", "--global", "--add", "safe.directory", "/epics/modules/std_1b416db"], "msg": "non-zero return code", "rc": 255, "stderr": "error: could not lock config file /home/softioc-tst/.gitconfig: No such file or directory"}
```

The `git config --global` command writes to `~/.gitconfig`, but in container environments the softioc user's home directory (`/home/softioc-tst`) does not exist. Git cannot create or lock the config file, so it fails with rc=255.

## Fix
Two new tasks are added at the top of `install-module.yml`, before either the standard module or epics_base git safe.directory tasks:

1. **Look up softioc user home directory** — uses `ansible.builtin.getent` to query `/etc/passwd` for the softioc user's home path
2. **Ensure softioc user home directory exists** — creates the directory (with correct owner/group/mode) if it is missing, using the path from `getent_passwd`

This is placed before the `Handle standard module` / `Handle epics_base` blocks so both code paths benefit from the fix.

## Test plan
- [x] Ran `pixi run deployment --container -t rbd9103` successfully
- The deployment log confirms the fix works — the home directory was absent and got created:
  ```
  TASK [nsls2.ioc_deploy.install_module : Look up softioc user home directory] ***
  ok: [nsls2_ioc_deploy_el8]

  TASK [nsls2.ioc_deploy.install_module : Ensure softioc user home directory exists] ***
  changed: [nsls2_ioc_deploy_el8]
  ```
  With the diff showing:
  ```diff
  -    "state": "absent"
  +    "state": "directory"
  ```
- The subsequent `Add module directory to git safe.directory list` task then succeeded
- Full playbook completed: `ok=110  changed=8  unreachable=0  failed=0`

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)