### PR TITLE
Changed version of adtimepix3

### DIFF
--- a/roles/deploy_ioc/vars/adtimepix3.yml
+++ b/roles/deploy_ioc/vars/adtimepix3.yml
@@ -2,7 +2,7 @@
 
 deploy_ioc_use_common: true
 deploy_ioc_use_ad_common: true
-deploy_ioc_required_module: 'adtimepix3_2faf970'
+deploy_ioc_required_module: 'adtimepix3_15009fe'
 deploy_ioc_executable: tpx3App
 
 deploy_ioc_template_root_path:

--- a/roles/install_module/vars/adtimepix3_15009fe.yml
+++ b/roles/install_module/vars/adtimepix3_15009fe.yml
@@ -1,8 +1,8 @@
 ---
 
-adtimepix3_2faf970:
+adtimepix3_15009fe:
   name: ADTimePix3
-  version: 2faf970
+  version: 15009fe
 
   url: https://github.com/areaDetector/ADTimePix3
   include_base_ad_config: true

--- a/roles/install_module/vars/adtimepix3_15009fe.yml
+++ b/roles/install_module/vars/adtimepix3_15009fe.yml
@@ -8,6 +8,8 @@ adtimepix3_15009fe:
   include_base_ad_config: true
   pkg_deps:
     - curl-devel
+  compilation_command:
+    "bash tpx3Support/jsonSrc/installJSON.sh && bash tpx3Support/cprSrc/installCPR.sh && make -sj"
   module_deps:
     - adcore_60080dc
     - adsupport_6acf83f


### PR DESCRIPTION
This PR modifies the yml files that pick the latest version of adtimepix3 to use an earlier version in order to make it compatible with the current version that is being run with the timepix3 at CHX.