### PR TITLE
base_soft_ioc role type

### DIFF
--- a/roles/deploy_ioc/vars/base_soft_ioc.yml
+++ b/roles/deploy_ioc/vars/base_soft_ioc.yml
@@ -1,0 +1,7 @@
+---
+
+deploy_ioc_use_common: true
+deploy_ioc_use_ad_common: false
+deploy_ioc_make_autosave_files: true
+deploy_ioc_required_module: base_soft_ioc_d6f341c
+deploy_ioc_executable: baseSoftIOC

--- a/roles/deploy_ioc/vars/base_soft_ioc.yml
+++ b/roles/deploy_ioc/vars/base_soft_ioc.yml
@@ -3,6 +3,6 @@
 deploy_ioc_use_common: true
 deploy_ioc_use_ad_common: false
 deploy_ioc_make_autosave_files: true
-deploy_ioc_required_module: base_soft_ioc_d6f341c
+deploy_ioc_required_module: base_soft_ioc_f4c87af
 deploy_ioc_executable: baseSoftIOC
 deploy_ioc_template_root_path: "{{ deploy_ioc_required_module_path }}"

--- a/roles/deploy_ioc/vars/base_soft_ioc.yml
+++ b/roles/deploy_ioc/vars/base_soft_ioc.yml
@@ -5,3 +5,4 @@ deploy_ioc_use_ad_common: false
 deploy_ioc_make_autosave_files: true
 deploy_ioc_required_module: base_soft_ioc_d6f341c
 deploy_ioc_executable: baseSoftIOC
+deploy_ioc_template_root_path: "{{ deploy_ioc_required_module_path }}"

--- a/roles/device_roles/base_soft_ioc/README.md
+++ b/roles/device_roles/base_soft_ioc/README.md
@@ -1,0 +1,3 @@
+# base_soft_ioc
+
+Ansible role for deploying base_soft_ioc IOC instances.

--- a/roles/device_roles/base_soft_ioc/examples/base-soft-ioc-01/config.yml
+++ b/roles/device_roles/base_soft_ioc/examples/base-soft-ioc-01/config.yml
@@ -1,0 +1,10 @@
+---
+
+base-soft-ioc-01:
+  type: base_soft_ioc
+  environment:
+    ENGINEER: C. Engineer
+    SYS: XF:31ID1-ES
+    DEV: "{IOC:1}"
+    PREFIX: "$(SYS)$(DEV)"
+    CT_PREFIX: "XF:31ID1-CT$(DEV)"

--- a/roles/device_roles/base_soft_ioc/examples/base-soft-ioc-01/verify.yml
+++ b/roles/device_roles/base_soft_ioc/examples/base-soft-ioc-01/verify.yml
@@ -1,0 +1,44 @@
+---
+# Set to true to skip module compilation (for roles requiring proprietary SDKs)
+skip_compilation: false
+
+verification:
+  files_must_exist:
+    # Standard IOC boot files (created by deploy_ioc)
+    - iocBoot/st.cmd
+    - iocBoot/epicsEnv.cmd
+    - iocBoot/postInit.cmd
+    # Role-specific files
+    - iocBoot/base.cmd
+
+  file_must_contain:
+    iocBoot/st.cmd:
+      - "iocInit"
+    iocBoot/base.cmd:
+      - "dbLoadDatabase"
+      - 'drvAsynIPPortConfigure("LS331", "127.0.0.1:8000")'
+      - 'asynOctetSetOutputEos("LS331", 0, "\r\n")'
+      - 'asynOctetSetInputEos("LS331", 0, "\r\n")'
+      - 'dbLoadTemplate("$(TOP)/db/lakeshore331.substitutions")'
+    db/lakeshore331.substitutions:
+      - 'file "$(TOP)/db/Lakeshore331.template"'
+      - '{ PORT, P, R }'
+      - '{ "LS331", "XF:31ID1-ES", "{LS331:1}" }'
+
+  file_must_not_contain:
+    iocBoot/st.cmd:
+      - "{{"  # No unrendered jinja
+      - "}}"
+    iocBoot/base.cmd:
+      - "{{"
+      - "}}"
+      - 'asynSetOption'
+    iocBoot/epicsEnv.cmd:
+      - "{{"
+      - "}}"
+    db/lakeshore331.substitutions:
+      - "{{"
+      - "}}"
+
+  permissions:
+    iocBoot/st.cmd: "0775"

--- a/roles/device_roles/base_soft_ioc/examples/base-soft-ioc-01/verify.yml
+++ b/roles/device_roles/base_soft_ioc/examples/base-soft-ioc-01/verify.yml
@@ -16,14 +16,7 @@ verification:
       - "iocInit"
     iocBoot/base.cmd:
       - "dbLoadDatabase"
-      - 'drvAsynIPPortConfigure("LS331", "127.0.0.1:8000")'
-      - 'asynOctetSetOutputEos("LS331", 0, "\r\n")'
-      - 'asynOctetSetInputEos("LS331", 0, "\r\n")'
-      - 'dbLoadTemplate("$(TOP)/db/lakeshore331.substitutions")'
-    db/lakeshore331.substitutions:
-      - 'file "$(TOP)/db/Lakeshore331.template"'
-      - '{ PORT, P, R }'
-      - '{ "LS331", "XF:31ID1-ES", "{LS331:1}" }'
+      - "baseSoftIOC_registerRecordDeviceDriver(pdbbase)"
 
   file_must_not_contain:
     iocBoot/st.cmd:
@@ -34,9 +27,6 @@ verification:
       - "}}"
       - 'asynSetOption'
     iocBoot/epicsEnv.cmd:
-      - "{{"
-      - "}}"
-    db/lakeshore331.substitutions:
       - "{{"
       - "}}"
 

--- a/roles/device_roles/base_soft_ioc/schema.yml
+++ b/roles/device_roles/base_soft_ioc/schema.yml
@@ -1,0 +1,30 @@
+---
+
+type: enum("lakeshore331")
+environment:
+  ENGINEER: str()
+  PREFIX: str()
+  PORT: str()
+  P: str()
+  R: str()
+  CT_PREFIX: str()
+connections: map(include('connection'), key=str())
+
+---
+connection:
+  type: enum("IP", "Serial")
+  connection: str()
+  output_eos: str()
+  input_eos: str()
+  serial_settings: include('serial_setting', required=False)
+
+serial_setting:
+  baud: enum(1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200)
+  bits: enum(8, 7, 6, 5)
+  parity: enum('none', 'even', 'odd')
+  stop: enum(1, 2)
+  clocal: enum('Y', 'N')
+  crtscts: enum('N', 'Y')
+  ixon: enum('N', 'Y')
+  ixoff: enum('N', 'Y')
+  ixany: enum('N', 'Y')

--- a/roles/device_roles/base_soft_ioc/schema.yml
+++ b/roles/device_roles/base_soft_ioc/schema.yml
@@ -1,30 +1,9 @@
 ---
 
-type: enum("lakeshore331")
+type: enum("base_soft_ioc")
 environment:
   ENGINEER: str()
   PREFIX: str()
-  PORT: str()
-  P: str()
-  R: str()
+  SYS: str()
+  DEV: str()
   CT_PREFIX: str()
-connections: map(include('connection'), key=str())
-
----
-connection:
-  type: enum("IP", "Serial")
-  connection: str()
-  output_eos: str()
-  input_eos: str()
-  serial_settings: include('serial_setting', required=False)
-
-serial_setting:
-  baud: enum(1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200)
-  bits: enum(8, 7, 6, 5)
-  parity: enum('none', 'even', 'odd')
-  stop: enum(1, 2)
-  clocal: enum('Y', 'N')
-  crtscts: enum('N', 'Y')
-  ixon: enum('N', 'Y')
-  ixoff: enum('N', 'Y')
-  ixany: enum('N', 'Y')

--- a/roles/device_roles/base_soft_ioc/tasks/main.yml
+++ b/roles/device_roles/base_soft_ioc/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Tasks for lakeshore331 role
+# Tasks for base_soft_ioc role
 - name: Create protocol directory
   ansible.builtin.file:
     path: "{{ deploy_ioc_ioc_directory }}/protocol"

--- a/roles/device_roles/base_soft_ioc/tasks/main.yml
+++ b/roles/device_roles/base_soft_ioc/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# Tasks for lakeshore331 role
+- name: Create protocol directory
+  ansible.builtin.file:
+    path: "{{ deploy_ioc_ioc_directory }}/protocol"
+    owner: "{{ host_config.softioc_user }}"
+    group: "{{ host_config.softioc_group }}"
+    state: directory
+    mode: "0775"
+
+- name: Install base startup script
+  ansible.builtin.template:
+    src: "templates/base.cmd.j2"
+    dest: "{{ deploy_ioc_ioc_directory }}/iocBoot/base.cmd"
+    owner: "{{ host_config.softioc_user }}"
+    group: "{{ host_config.softioc_group }}"
+    mode: "0664"

--- a/roles/device_roles/base_soft_ioc/templates/base.cmd.j2
+++ b/roles/device_roles/base_soft_ioc/templates/base.cmd.j2
@@ -1,0 +1,2 @@
+dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable }}.dbd")
+{{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)

--- a/roles/install_module/vars/base_soft_ioc_d6f341c.yml
+++ b/roles/install_module/vars/base_soft_ioc_d6f341c.yml
@@ -1,0 +1,6 @@
+---
+base_soft_ioc_d6f341c:
+  name: BaseSoftIOC
+  url: https://github.com/NSLS2/BaseSoftIOC
+  version: d6f341c
+  executable: "baseSoftIOC"

--- a/roles/install_module/vars/base_soft_ioc_f4c87af.yml
+++ b/roles/install_module/vars/base_soft_ioc_f4c87af.yml
@@ -1,6 +1,6 @@
 ---
-base_soft_ioc_d6f341c:
+base_soft_ioc_f4c87af:
   name: BaseSoftIOC
   url: https://github.com/NSLS2/BaseSoftIOC
-  version: d6f341c
+  version: f4c87af
   executable: "baseSoftIOC"


### PR DESCRIPTION
New role type `base_soft_ioc` can be used to run custom beamline-specific soft IOCs. The IOC logic must be defined in custom .db files. The IOC provides the means to execute those files. 