### PR TITLE
zpsc: bump to ce70f0d, fix wfmstats.db macro args

### DIFF
--- a/roles/deploy_ioc/vars/zpsc.yml
+++ b/roles/deploy_ioc/vars/zpsc.yml
@@ -1,6 +1,6 @@
 ---
 
-deploy_ioc_required_module: zpsc_13fff72
+deploy_ioc_required_module: zpsc_ce70f0d
 deploy_ioc_executable: zpsc
 deploy_ioc_template_root_path: "{{ install_module_leaf_module_path }}"
 deploy_ioc_use_common: true

--- a/roles/device_roles/zpsc/templates/base.cmd.j2
+++ b/roles/device_roles/zpsc/templates/base.cmd.j2
@@ -31,7 +31,7 @@ dbLoadRecords("db/snapshots.db", "P=$(SYSTEMS), NO=$(NUM), DEVICE=$(DEVICE), TYP
 dbLoadRecords("db/snapshots.db", "P=$(SYSTEMS), NO=$(NUM), DEVICE=$(DEVICE), TYPE=EVR, CHAN=2, MSGID=101, BUFLEN=$(BLEN)")
 dbLoadRecords("db/snapshots.db", "P=$(SYSTEMS), NO=$(NUM), DEVICE=$(DEVICE), TYPE=EVR, CHAN=3, MSGID=102, BUFLEN=$(BLEN)")
 dbLoadRecords("db/snapshots.db", "P=$(SYSTEMS), NO=$(NUM), DEVICE=$(DEVICE), TYPE=EVR, CHAN=4, MSGID=103, BUFLEN=$(BLEN)")
-dbLoadRecords("db/wfmstats.db", "P=$(SYSTEMS), PSC=$(DEVICE)$(NUM)")
+dbLoadRecords("db/wfmstats.db",  "P=$(SYSTEMS), NO=$(NUM), DEVICE=$(DEVICE)")
 #dbLoadRecords("db/asub_test.db")
 epicsThreadSleep(5)
 var(PSCDebug, 0)	#5 full debug   #0: zero debug

--- a/roles/install_module/vars/zpsc_ce70f0d.yml
+++ b/roles/install_module/vars/zpsc_ce70f0d.yml
@@ -1,8 +1,8 @@
 ---
-zpsc_13fff72:
+zpsc_ce70f0d:
   name: ZPSC
   url: https://github.com/NSLS2/zPSC.git
-  version: 13fff72
+  version: ce70f0d
   compilation_command: "make -s"
   module_deps:
     - pscdrv_1ed650d


### PR DESCRIPTION
The upstream zPSC IOC was modified. The role needs to upgraded. 