### PR TITLE
Fix for ADAravis role

### DIFF
--- a/roles/deploy_ioc/vars/adaravis.yml
+++ b/roles/deploy_ioc/vars/adaravis.yml
@@ -5,6 +5,7 @@ deploy_ioc_required_module: adaravis_a0aa4d6
 deploy_ioc_template_root_path:
   "{{ deploy_ioc_required_module_path }}/iocs/aravisIOC"
 deploy_ioc_as_dir_name: autosave
+adaravis_arv_tool: arv-tool-0.8
 deploy_ioc_req_file_list:
   - name: auto_settings.req
     macros: "P=$(PREFIX)"

--- a/roles/deploy_ioc/vars/adaravis.yml
+++ b/roles/deploy_ioc/vars/adaravis.yml
@@ -5,7 +5,6 @@ deploy_ioc_required_module: adaravis_a0aa4d6
 deploy_ioc_template_root_path:
   "{{ deploy_ioc_required_module_path }}/iocs/aravisIOC"
 deploy_ioc_as_dir_name: autosave
-deploy_ioc_adaravis_arv_tool: arv-tool
 deploy_ioc_req_file_list:
   - name: auto_settings.req
     macros: "P=$(PREFIX)"

--- a/roles/deploy_ioc/vars/adaravis.yml
+++ b/roles/deploy_ioc/vars/adaravis.yml
@@ -5,7 +5,7 @@ deploy_ioc_required_module: adaravis_a0aa4d6
 deploy_ioc_template_root_path:
   "{{ deploy_ioc_required_module_path }}/iocs/aravisIOC"
 deploy_ioc_as_dir_name: autosave
-adaravis_arv_tool: arv-tool-0.8
+deploy_ioc_adaravis_arv_tool: arv-tool
 deploy_ioc_req_file_list:
   - name: auto_settings.req
     macros: "P=$(PREFIX)"

--- a/roles/device_roles/adaravis/example.yml
+++ b/roles/device_roles/adaravis/example.yml
@@ -8,5 +8,5 @@ adaravis-01:
     # For camera name, use `/opt/aravis/bin/arv-tool-0.8` to list all cameras
     # find the one with the IP you assigned to it, and copy the entire entry
     # without the IP.
-    CAMERA_NAME: "Allied Vision-Manta G-040B (E0022660)-50-0503548886"
+    CAMERA_NAME: "Allied Vision Technologies-Manta G-040B (E0022660)-50-0503548886"
     ENABLE_CACHING: 1

--- a/roles/device_roles/adaravis/tasks/autogen_files.yml
+++ b/roles/device_roles/adaravis/tasks/autogen_files.yml
@@ -12,9 +12,13 @@
     state: directory
     mode: "02775"
 
+- name: Set Aravis tool name
+  ansible.builtin.set_fact:
+    adaravis_arv_tool: "arv-tool"
+
 - name: Use arv-tool to generate xml file from camera
   ansible.builtin.shell: >-
-    {{ deploy_ioc_adaravis_arv_tool }} -n "{{ ioc.environment.CAMERA_NAME }}" genicam >
+    {{ adaravis_arv_tool }} -n "{{ ioc.environment.CAMERA_NAME }}" genicam >
     {{ deploy_ioc_ioc_directory }}/xml/{{ adaravis_camera_model_name }}.xml
   register: arv_tool_result
   changed_when: >-

--- a/roles/device_roles/adaravis/tasks/autogen_files.yml
+++ b/roles/device_roles/adaravis/tasks/autogen_files.yml
@@ -37,10 +37,7 @@
   register: venv_result
   changed_when: >-
     not ansible_check_mode and
-    venv_result.rc == 0 and
-    not (lookup('ansible.builtin.stat', venv_path).exists)
-  vars:
-    venv_path: "{{ deploy_ioc_ioc_directory }}/genicam-xml-converters/venv"
+    venv_result.rc == 0
 
 - name: Autogenerate database files from xml
   ansible.builtin.shell: >-

--- a/roles/device_roles/adaravis/tasks/autogen_files.yml
+++ b/roles/device_roles/adaravis/tasks/autogen_files.yml
@@ -14,7 +14,7 @@
 
 - name: Use arv-tool to generate xml file from camera
   ansible.builtin.shell: >-
-    {{ adaravis_arv_tool }} -n "{{ ioc.environment.CAMERA_NAME }}" genicam >
+    {{ deploy_ioc_adaravis_arv_tool }} -n "{{ ioc.environment.CAMERA_NAME }}" genicam >
     {{ deploy_ioc_ioc_directory }}/xml/{{ adaravis_camera_model_name }}.xml
   register: arv_tool_result
   changed_when: >-

--- a/roles/device_roles/adaravis/tasks/main.yml
+++ b/roles/device_roles/adaravis/tasks/main.yml
@@ -29,7 +29,6 @@
 - name: Auto generate feature databases and bob screens
   ansible.builtin.include_tasks: autogen_files.yml
 
-
 - name: Install base startup script
   ansible.builtin.template:
     src: "templates/base.cmd.j2"


### PR DESCRIPTION
The fix includes the following changes:

- Set the name for the aravis tool: `adaravis_arv_tool: arv-tool`.
- Removed the condition `not (lookup('ansible.builtin.stat', venv_path).exists)` as incorrect and redundant.
- Fixed the camera name in the example.

The role was successfully tested on xf31id1-lab3-ioc1 machine.