### PR TITLE
add socat PTY bridge support to lakeshore331 role

### DIFF
--- a/roles/device_roles/lakeshore331/examples/lakeshore331-moxa/config.yml
+++ b/roles/device_roles/lakeshore331/examples/lakeshore331-moxa/config.yml
@@ -1,0 +1,23 @@
+---
+
+# Moxa terminal server via socat PTY bridge.
+# Deploys a systemd service that bridges TCP to a local PTY device,
+# eliminating the need for the npreal2 kernel module.
+# When MOXA_HOST/MOXA_PORT are set, the asyn port auto-points at
+# /dev/lakeshore-pty-<ioc_name> and any `connection:` value below is ignored.
+lakeshore331-moxa:
+  type: lakeshore331
+  environment:
+    ENGINEER: C. Engineer
+    PORT: LS331
+    P: XF:31ID1-ES
+    R: "{LS331:1}"
+    PREFIX: "$(P)$(R)"
+    CT_PREFIX: "XF:31ID1-CT{LS331:1}"
+    MOXA_HOST: "10.68.42.77"
+    MOXA_PORT: "4002"
+  connections:
+    LS331:
+      type: "Serial"
+      output_eos: "\\r\\n"
+      input_eos: "\\r\\n"

--- a/roles/device_roles/lakeshore331/examples/lakeshore331-moxa/config.yml
+++ b/roles/device_roles/lakeshore331/examples/lakeshore331-moxa/config.yml
@@ -19,5 +19,9 @@ lakeshore331-moxa:
   connections:
     LS331:
       type: "Serial"
+      # `connection` is required by the schema but is ignored when
+      # MOXA_HOST/MOXA_PORT are set; the role auto-points the asyn port
+      # at the socat-managed PTY shown below.
+      connection: "/dev/lakeshore-pty-lakeshore331-moxa"
       output_eos: "\\r\\n"
       input_eos: "\\r\\n"

--- a/roles/device_roles/lakeshore331/examples/lakeshore331-moxa/verify.yml
+++ b/roles/device_roles/lakeshore331/examples/lakeshore331-moxa/verify.yml
@@ -1,0 +1,46 @@
+---
+# Set to true to skip module compilation (for roles requiring proprietary SDKs)
+skip_compilation: false
+
+verification:
+  files_must_exist:
+    # Standard IOC boot files (created by deploy_ioc)
+    - iocBoot/st.cmd
+    - iocBoot/epicsEnv.cmd
+    - iocBoot/postInit.cmd
+    # Role-specific files
+    - iocBoot/base.cmd
+    - db/Lakeshore331.template
+    - db/lakeshore331.substitutions
+
+  file_must_contain:
+    iocBoot/st.cmd:
+      - "iocInit"
+    iocBoot/base.cmd:
+      - "dbLoadDatabase"
+      - 'drvAsynSerialPortConfigure("LS331", "/dev/lakeshore-pty-lakeshore331-moxa")'
+      - 'asynOctetSetOutputEos("LS331", 0, "\r\n")'
+      - 'asynOctetSetInputEos("LS331", 0, "\r\n")'
+      - 'dbLoadTemplate("$(TOP)/db/lakeshore331.substitutions")'
+    db/lakeshore331.substitutions:
+      - 'file "$(TOP)/db/Lakeshore331.template"'
+      - '{ PORT, P, R }'
+      - '{ "LS331", "XF:31ID1-ES", "{LS331:1}" }'
+
+  file_must_not_contain:
+    iocBoot/st.cmd:
+      - "{{"  # No unrendered jinja
+      - "}}"
+    iocBoot/base.cmd:
+      - "{{"
+      - "}}"
+      - 'drvAsynIPPortConfigure'
+    iocBoot/epicsEnv.cmd:
+      - "{{"
+      - "}}"
+    db/lakeshore331.substitutions:
+      - "{{"
+      - "}}"
+
+  permissions:
+    iocBoot/st.cmd: "0775"

--- a/roles/device_roles/lakeshore331/handlers/main.yml
+++ b/roles/device_roles/lakeshore331/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true

--- a/roles/device_roles/lakeshore331/schema.yml
+++ b/roles/device_roles/lakeshore331/schema.yml
@@ -8,12 +8,14 @@ environment:
   P: str()
   R: str()
   CT_PREFIX: str()
+  MOXA_HOST: str(required=False)  # Moxa terminal server IP/hostname (socat PTY bridge)
+  MOXA_PORT: str(required=False)  # Moxa TCP port (socat PTY bridge)
 connections: map(include('connection'), key=str())
 
 ---
 connection:
   type: enum("IP", "Serial")
-  connection: str()
+  connection: str(required=False)  # ignored when MOXA_HOST/MOXA_PORT are set; auto-points at /dev/lakeshore-pty-<ioc_name>
   output_eos: str()
   input_eos: str()
   serial_settings: include('serial_setting', required=False)

--- a/roles/device_roles/lakeshore331/schema.yml
+++ b/roles/device_roles/lakeshore331/schema.yml
@@ -15,7 +15,7 @@ connections: map(include('connection'), key=str())
 ---
 connection:
   type: enum("IP", "Serial")
-  connection: str(required=False)  # ignored when MOXA_HOST/MOXA_PORT are set; auto-points at /dev/lakeshore-pty-<ioc_name>
+  connection: str()  # ignored when MOXA_HOST/MOXA_PORT are set; auto-points at /dev/lakeshore-pty-<ioc_name>
   output_eos: str()
   input_eos: str()
   serial_settings: include('serial_setting', required=False)

--- a/roles/device_roles/lakeshore331/tasks/main.yml
+++ b/roles/device_roles/lakeshore331/tasks/main.yml
@@ -1,5 +1,55 @@
 ---
 # Tasks for lakeshore331 role
+
+# socat PTY bridge for Moxa terminal server connections.
+# Replaces the fragile npreal2 kernel module with a userspace PTY bridge
+# that survives kernel updates without manual intervention.
+- name: Set up socat PTY bridge for Moxa serial connection
+  when: "ioc.environment.get('MOXA_HOST') and ioc.environment.get('MOXA_PORT')"
+  block:
+    - name: Ensure socat is installed
+      ansible.builtin.dnf:
+        name: socat
+        state: present
+
+    - name: Deploy lakeshore PTY bridge systemd service
+      ansible.builtin.template:
+        src: templates/lakeshore-pty.service.j2
+        dest: "/etc/systemd/system/lakeshore-pty-{{ deploy_ioc_ioc_name }}.service"
+        mode: "0644"
+        owner: root
+        group: root
+      register: lakeshore331_pty_service
+
+    - name: Enable and start lakeshore PTY bridge
+      ansible.builtin.systemd:
+        name: "lakeshore-pty-{{ deploy_ioc_ioc_name }}"
+        enabled: true
+        state: "{{ 'restarted' if lakeshore331_pty_service.changed else 'started' }}"
+        daemon_reload: "{{ lakeshore331_pty_service.changed }}"
+
+- name: Clean up stale socat PTY bridge if Moxa config removed
+  when: "not (ioc.environment.get('MOXA_HOST') and ioc.environment.get('MOXA_PORT'))"
+  block:
+    - name: Check if lakeshore PTY bridge service exists
+      ansible.builtin.stat:
+        path: "/etc/systemd/system/lakeshore-pty-{{ deploy_ioc_ioc_name }}.service"
+      register: lakeshore331_pty_service_file
+
+    - name: Stop and disable stale lakeshore PTY bridge
+      ansible.builtin.systemd:
+        name: "lakeshore-pty-{{ deploy_ioc_ioc_name }}"
+        enabled: false
+        state: stopped
+        daemon_reload: true
+      when: lakeshore331_pty_service_file.stat.exists
+
+    - name: Remove stale lakeshore PTY bridge service file
+      ansible.builtin.file:
+        path: "/etc/systemd/system/lakeshore-pty-{{ deploy_ioc_ioc_name }}.service"
+        state: absent
+      when: lakeshore331_pty_service_file.stat.exists
+
 - name: Create protocol directory
   ansible.builtin.file:
     path: "{{ deploy_ioc_ioc_directory }}/protocol"

--- a/roles/device_roles/lakeshore331/tasks/main.yml
+++ b/roles/device_roles/lakeshore331/tasks/main.yml
@@ -60,13 +60,8 @@
       ansible.builtin.file:
         path: "/etc/systemd/system/lakeshore-pty-{{ deploy_ioc_ioc_name }}.service"
         state: absent
-      register: lakeshore331_pty_service_file_removed
       when: lakeshore331_pty_service_file.stat.exists
-
-    - name: Reload systemd after removing stale lakeshore PTY bridge service file
-      ansible.builtin.systemd:
-        daemon_reload: true
-      when: lakeshore331_pty_service_file_removed.changed
+      notify: Reload systemd
 
 - name: Create protocol directory
   ansible.builtin.file:

--- a/roles/device_roles/lakeshore331/tasks/main.yml
+++ b/roles/device_roles/lakeshore331/tasks/main.yml
@@ -41,14 +41,19 @@
         name: "lakeshore-pty-{{ deploy_ioc_ioc_name }}"
         enabled: false
         state: stopped
-        daemon_reload: true
       when: lakeshore331_pty_service_file.stat.exists
 
     - name: Remove stale lakeshore PTY bridge service file
       ansible.builtin.file:
         path: "/etc/systemd/system/lakeshore-pty-{{ deploy_ioc_ioc_name }}.service"
         state: absent
+      register: lakeshore331_pty_service_file_removed
       when: lakeshore331_pty_service_file.stat.exists
+
+    - name: Reload systemd after removing stale lakeshore PTY bridge service file
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when: lakeshore331_pty_service_file_removed.changed
 
 - name: Create protocol directory
   ansible.builtin.file:

--- a/roles/device_roles/lakeshore331/tasks/main.yml
+++ b/roles/device_roles/lakeshore331/tasks/main.yml
@@ -7,6 +7,19 @@
 - name: Set up socat PTY bridge for Moxa serial connection
   when: "ioc.environment.get('MOXA_HOST') and ioc.environment.get('MOXA_PORT')"
   block:
+    - name: Validate that all connections are type Serial when using MOXA
+      ansible.builtin.assert:
+        that:
+          - "item.value.type == 'Serial'"
+        fail_msg: >-
+          Connection '{{ item.key }}' has type '{{ item.value.type }}'.
+          When MOXA_HOST/MOXA_PORT are set, all connections must be type
+          'Serial' (the asyn port is auto-configured to point at
+          /dev/lakeshore-pty-{{ deploy_ioc_ioc_name }}).
+      loop: "{{ ioc.connections | dict2items if ioc.connections is defined else [] }}"
+      loop_control:
+        label: "{{ item.key }}"
+
     - name: Ensure socat is installed
       ansible.builtin.dnf:
         name: socat

--- a/roles/device_roles/lakeshore331/templates/base.cmd.j2
+++ b/roles/device_roles/lakeshore331/templates/base.cmd.j2
@@ -7,9 +7,18 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 
 # ============================ BASE STREAM DEVICE CONFIGURATION ============================
 # Configure all asyn port connections
+{% set is_moxa = ioc.environment.get('MOXA_HOST') and ioc.environment.get('MOXA_PORT') %}
+{% if is_moxa %}
+# Connection via socat PTY bridge to Moxa terminal server
+# Managed by systemd service: lakeshore-pty-{{ deploy_ioc_ioc_name }}
+{% endif %}
 {% if ioc.connections is defined %}
 {% for connection in ioc.connections|dict2items %}
+{% if is_moxa %}
+drvAsynSerialPortConfigure("{{ connection.key }}", "/dev/lakeshore-pty-{{ deploy_ioc_ioc_name }}")
+{% else %}
 drvAsyn{{ connection.value.type }}PortConfigure("{{ connection.key }}", "{{ connection.value.connection }}")
+{% endif %}
 {% if connection.value.serial_settings is defined %}
 {% for serial_setting in connection.value.serial_settings %}
 asynSetOption("{{ connection.key }}", 0, "{{ serial_setting }}", "{{ serial_settings[serial_setting] }}")

--- a/roles/device_roles/lakeshore331/templates/base.cmd.j2
+++ b/roles/device_roles/lakeshore331/templates/base.cmd.j2
@@ -14,10 +14,18 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 {% endif %}
 {% if ioc.connections is defined %}
 {% for connection in ioc.connections|dict2items %}
+{% set connection_type = connection.value.type %}
+{% if connection_type == 'Serial' %}
 {% if is_moxa %}
 drvAsynSerialPortConfigure("{{ connection.key }}", "/dev/lakeshore-pty-{{ deploy_ioc_ioc_name }}")
 {% else %}
-drvAsyn{{ connection.value.type }}PortConfigure("{{ connection.key }}", "{{ connection.value.connection }}")
+drvAsynSerialPortConfigure("{{ connection.key }}", "{{ connection.value.connection }}")
+{% endif %}
+{% elif is_moxa %}
+{# MOXA PTY bridging is only valid for Serial connections; fail template rendering for incompatible types. #}
+{% set _moxa_requires_serial_connection_type = 1 / 0 %}
+{% else %}
+drvAsyn{{ connection_type }}PortConfigure("{{ connection.key }}", "{{ connection.value.connection }}")
 {% endif %}
 {% if connection.value.serial_settings is defined %}
 {% for serial_setting in connection.value.serial_settings %}

--- a/roles/device_roles/lakeshore331/templates/lakeshore-pty.service.j2
+++ b/roles/device_roles/lakeshore331/templates/lakeshore-pty.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Lakeshore serial PTY bridge via socat ({{ deploy_ioc_ioc_name }})
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/socat \
+    PTY,link=/dev/lakeshore-pty-{{ deploy_ioc_ioc_name }},raw,echo=0,mode=0664,user={{ host_config.softioc_user }},group-late={{ host_config.softioc_group }} \
+    TCP:{{ ioc.environment.MOXA_HOST }}:{{ ioc.environment.MOXA_PORT }},retry,interval=5,forever
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Mirrors the linkamt96 socat PTY bridge pattern for the lakeshore331 role.

When `MOXA_HOST` and `MOXA_PORT` are set in the IOC environment, the role deploys a per-IOC systemd socat service that bridges TCP to a local PTY at `/dev/lakeshore-pty-<ioc_name>`, and the asyn port is auto-configured as Serial pointing at that PTY. Existing IP/Serial behavior is unchanged when these fields are absent.

New example: `lakeshore331-moxa`.