### PR TITLE
updated deploy_ioc_template_root_path for tetramm

### DIFF
--- a/roles/deploy_ioc/vars/tetramm.yml
+++ b/roles/deploy_ioc/vars/tetramm.yml
@@ -2,7 +2,7 @@
 deploy_ioc_standard_st_cmd: true
 deploy_ioc_executable: "quadEMTestApp"
 deploy_ioc_as_dir_name: autosave
-deploy_ioc_template_root_path: /epics/modules/quadEM
+deploy_ioc_template_root_path: /epics/modules/quadem_f5ab1e9
 deploy_ioc_required_module: quadem_f5ab1e9
 deploy_ioc_use_common: true
 deploy_ioc_req_file_list:

--- a/roles/deploy_ioc/vars/tetramm.yml
+++ b/roles/deploy_ioc/vars/tetramm.yml
@@ -2,7 +2,7 @@
 deploy_ioc_standard_st_cmd: true
 deploy_ioc_executable: "quadEMTestApp"
 deploy_ioc_as_dir_name: autosave
-deploy_ioc_template_root_path: /epics/modules/quadem_f5ab1e9
+deploy_ioc_template_root_path: "{{ deploy_ioc_required_module_path }}"
 deploy_ioc_required_module: quadem_f5ab1e9
 deploy_ioc_use_common: true
 deploy_ioc_req_file_list:


### PR DESCRIPTION
Kept getting: 
`/epics/iocs/tetramm/st.cmd: ./st.cmd: /epics/modules/quadEM/bin/linux-x86_64/quadEMTestApp: bad interpreter: No such file or directory`

I believe it should be:
`/epics/modules/quadem_f5ab1e9`, which does exist.
