### PR TITLE
Fixed input parameters for ip and port number for ADXSPDConfig

### DIFF
--- a/roles/device_roles/adxspd/templates/base.cmd.j2
+++ b/roles/device_roles/adxspd/templates/base.cmd.j2
@@ -4,9 +4,9 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 
 # adxspd specific commands
 {% if ioc.environment.DEVICE_ID is defined %}
-ADXSPDConfig("$(PORT)", "$(IP):$(PORT_NUM)", "$(DEVICE_ID)")
+ADXSPDConfig("$(PORT)", "$(IP)", "$(PORT_NUM)", "$(DEVICE_ID)")
 {% else %}
-ADXSPDConfig("$(PORT)", "$(IP):$(PORT_NUM)")
+ADXSPDConfig("$(PORT)", "$(IP)", "$(PORT_NUM)")
 {% endif %}
 
 dbLoadRecords("$(ADXSPD)/db/ADXSPD.template","P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")


### PR DESCRIPTION
This PR fixes an issue found when running ADXSPDConfig. The ip and port number need to be split to separate input parameters in order to meet the correct format of the original function.