### PR TITLE
Initialize deploy_ioc_loop_index if the role is called directly (not from the loop)

### DIFF
--- a/roles/deploy_ioc/tasks/deploy-ioc.yml
+++ b/roles/deploy_ioc/tasks/deploy-ioc.yml
@@ -3,6 +3,11 @@
 - name: Set deployment facts
   ansible.builtin.include_tasks: set-facts.yml
 
+- name: Initialize deploy_ioc_loop_index only if not defined
+  ansible.builtin.set_fact:
+    deploy_ioc_loop_index: 0
+  when: deploy_ioc_loop_index is not defined
+
 - name: Stop existing IOC instance if running
   when: >
     deploy_ioc_post_deploy_step == "Restart" or


### PR DESCRIPTION
The `deploy-ioc` role fails if it is called directly for a single IOC (not from the loop). In the proposed change the `deploy_ioc_loop_index` variable is initialized with 0 if it is not defined.

The issue happens when the IOC is installed from runansible using

```
pixi run deployment -l <host_name> -t <ioc_name>
```