### PR TITLE
Fixed the priority of deploy_ioc_executable definitions

### DIFF
--- a/roles/deploy_ioc/defaults/main.yml
+++ b/roles/deploy_ioc/defaults/main.yml
@@ -17,7 +17,7 @@ deploy_ioc_post_deploy_step: "None"
 # The two below are concatenated to form the full IOC executable path,
 # and its associated dbd file. These can be overridden as needed.
 deploy_ioc_template_root_path: "/usr/lib/epics"
-deploy_ioc_executable: "softIoc"
+deploy_ioc_executable_default_: "softIoc"
 
 # Use standard st.cmd file, which loads `epicsEnv.cmd`, `base.cmd`, `common.cmd`,
 # executes iocInit(), and then loads `postInit.cmd`

--- a/roles/deploy_ioc/defaults/main.yml
+++ b/roles/deploy_ioc/defaults/main.yml
@@ -17,6 +17,7 @@ deploy_ioc_post_deploy_step: "None"
 # The two below are concatenated to form the full IOC executable path,
 # and its associated dbd file. These can be overridden as needed.
 deploy_ioc_template_root_path: "/usr/lib/epics"
+deploy_ioc_executable: none
 deploy_ioc_executable_default_: "softIoc"
 
 # Use standard st.cmd file, which loads `epicsEnv.cmd`, `base.cmd`, `common.cmd`,

--- a/roles/deploy_ioc/tasks/set-facts.yml
+++ b/roles/deploy_ioc/tasks/set-facts.yml
@@ -26,7 +26,7 @@
 - name: Initialize executable name defined in module parameters
   ansible.builtin.set_fact:
     deploy_ioc_executable_module_: none
-    
+
 - name: Handle any module requirements
   when: deploy_ioc_required_module is defined or ioc.required_module is defined
   block:

--- a/roles/deploy_ioc/tasks/set-facts.yml
+++ b/roles/deploy_ioc/tasks/set-facts.yml
@@ -129,14 +129,14 @@
 
 - name: Set IOC exe name to the name defined in module parameters
   ansible.builtin.set_fact:
-    deploy_ioc_executable: "{{ deploy_ioc_executable_module_ }}" 
+    deploy_ioc_executable: "{{ deploy_ioc_executable_module_ }}"
   when: deploy_ioc_executable is not defined and deploy_ioc_executable_module_ is defined
 
 - name: Set IOC exe name to the default name
   ansible.builtin.set_fact:
-    deploy_ioc_executable: "{{ deploy_ioc_executable_default_ }}" 
+    deploy_ioc_executable: "{{ deploy_ioc_executable_default_ }}"
   when: deploy_ioc_executable is not defined
-  
+
 - name: Get list of substitution files
   ansible.builtin.set_fact:
     substitutions: "{{ ioc.substitutions }}"

--- a/roles/deploy_ioc/tasks/set-facts.yml
+++ b/roles/deploy_ioc/tasks/set-facts.yml
@@ -48,7 +48,7 @@
 
     - name: If specified, override ioc exe with installed module exe
       ansible.builtin.set_fact:
-        deploy_ioc_executable: "{{ install_module_leaf_executable }}"
+        deploy_ioc_executable_module_: "{{ install_module_leaf_executable }}"
       when: install_module_leaf_executable is defined
 
 - name: Get default environment variables for ioc type
@@ -127,6 +127,16 @@
     deploy_ioc_executable: "{{ ioc.executable }}"
   when: ioc.executable is defined
 
+- name: Set IOC exe name to the name defined in module parameters
+  ansible.builtin.set_fact:
+    deploy_ioc_executable: "{{ deploy_ioc_executable_module_ }}" 
+  when: deploy_ioc_executable is not defined and deploy_ioc_executable_module_ is defined
+
+- name: Set IOC exe name to the default name
+  ansible.builtin.set_fact:
+    deploy_ioc_executable: "{{ deploy_ioc_executable_default_ }}" 
+  when: deploy_ioc_executable is not defined
+  
 - name: Get list of substitution files
   ansible.builtin.set_fact:
     substitutions: "{{ ioc.substitutions }}"

--- a/roles/deploy_ioc/tasks/set-facts.yml
+++ b/roles/deploy_ioc/tasks/set-facts.yml
@@ -23,6 +23,10 @@
     and ansible_distribution == "RedHat"
     and ansible_distribution_major_version | int not in deploy_ioc_supported_el_versions
 
+- name: Initialize executable name defined in module parameters
+  ansible.builtin.set_fact:
+    deploy_ioc_executable_module_: none
+    
 - name: Handle any module requirements
   when: deploy_ioc_required_module is defined or ioc.required_module is defined
   block:
@@ -130,12 +134,12 @@
 - name: Set IOC exe name to the name defined in module parameters
   ansible.builtin.set_fact:
     deploy_ioc_executable: "{{ deploy_ioc_executable_module_ }}"
-  when: deploy_ioc_executable is not defined and deploy_ioc_executable_module_ is defined
+  when: deploy_ioc_executable is none and deploy_ioc_executable_module_ is not none
 
 - name: Set IOC exe name to the default name
   ansible.builtin.set_fact:
     deploy_ioc_executable: "{{ deploy_ioc_executable_default_ }}"
-  when: deploy_ioc_executable is not defined
+  when: deploy_ioc_executable is none
 
 - name: Get list of substitution files
   ansible.builtin.set_fact:


### PR DESCRIPTION
Implement correct priority of definitions of 'deploy_ioc_executable' (from lowest to highest):
- definition in required module parameters;
- definition in ioc role parameters;
- definition in ioc instance parameters;
- default definition (`softIoc`).
