### PR TITLE
Increase callback queue size (nsls2em role)

### DIFF
--- a/roles/deploy_ioc/vars/nsls2em.yml
+++ b/roles/deploy_ioc/vars/nsls2em.yml
@@ -11,8 +11,6 @@ deploy_ioc_dbpf_list:
   - pv: $(PREFIX)Reg31-Sp
     value: 0
     sleep: 1
-  - pv: $(PREFIX)regsend.SCAN
-    value: ".02 second"
   - pv: $(PREFIX)Reg8-Sp
     value: 7520
   - pv: $(PREFIX)Reg49-I.FLNK

--- a/roles/device_roles/nsls2em/templates/base.cmd.j2
+++ b/roles/device_roles/nsls2em/templates/base.cmd.j2
@@ -3,7 +3,7 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 {{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)
 
 # Increase callback queue size to prevent "callbackRequest: cbLow ring buffer full"
-callbackSetQueueSize(30000)
+callbackSetQueueSize(32768)
 
 # nsls2em specific commands
 drvAsynIPPortConfigure("IP_$(PORT)", "$(DEVICE_IP):17", 0, 0, 0)

--- a/roles/device_roles/nsls2em/templates/base.cmd.j2
+++ b/roles/device_roles/nsls2em/templates/base.cmd.j2
@@ -2,6 +2,9 @@
 dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable }}.dbd")
 {{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)
 
+# Increase callback queue size to prevent "callbackRequest: cbLow ring buffer full"
+callbackSetQueueSize(30000)
+
 # nsls2em specific commands
 drvAsynIPPortConfigure("IP_$(PORT)", "$(DEVICE_IP):17", 0, 0, 0)
 asynOctetSetInputEos("IP_$(PORT)",  0, "\r\n")


### PR DESCRIPTION
nsls2em role: increase callback queue size to prevent "callbackRequest: cbLow ring buffer full" during startup