### PR TITLE
Make the elio role more flexible - automatically get num terminals, num channels per terminal, and allow for customizing specific record fields

### DIFF
--- a/roles/device_roles/elio/example.yml
+++ b/roles/device_roles/elio/example.yml
@@ -1,29 +1,39 @@
 ---
 
 gpio_ex1:
-    type: "elio"
-    terminals:
-        # POS, MODEL
-        - ["1", "EL3068"]
-        - ["2", "EL4008"]
-        - ["3", "EL1808"]
-        - ["4", "EL1808"]
-        - ["5", "EL2808"]
-        - ["6", "EL2808"]
-        - ["7", "EL3068"]
-        - ["8", "EL1124"]
-        - ["9", "EL2124"]
+  type: "elio"
+  terminals:
+    - POS: 1
+      MODEL: "EL3068"
+    - POS: 2
+      MODEL: "EL4008"
+    - POS: 3
+      MODEL: "EL1808"
+    - POS: 4
+      MODEL: "EL1808"
+    - POS: 5
+      MODEL: "EL2808"
+    - POS: 6
+      MODEL: "EL2808"
+    - POS: 7
+      MODEL: "EL3068"
+    - POS: 8
+      MODEL: "EL1124"
+    - POS: 9
+      MODEL: "EL3008"
+      CHAN_SPECIFIC_CONFIG:
+        1: {"LINR": "SLOPE", "EGU": "V"}
+        2: {"LINR": "SLOPE", "EGU": "mA"}
 
-    # SYS and DEV: used to generate prefix for each device
-    # PREFIX: used for IOC-specific PVs
-    # HOST may be an IP address or host name
-    # EK9K: port name
-    # NUM_TERMS: total terminal numbers
-    environment:
-        SYS: "XF:31ID1-ES"
-        DEV: "GPIO:1"
-        EK9K: EK9K1
-        HOST: 10.69.58.101
-        NUM_TERMS: 9
-        PREFIX: "XF:31ID1-CT{IOC:GPIO1}"
-        ENGINEER: "H. Xu"    # Your name/contact info
+  # SYS and DEV: used to generate prefix for each device
+  # PREFIX: used for IOC-specific PVs
+  # HOST may be an IP address or host name
+  # EK9K: port name
+  # NUM_TERMS: total terminal numbers
+  environment:
+    SYS: "XF:31ID1-ES"
+    DEV: "GPIO:1"
+    EK9K: EK9K1
+    HOST: 10.69.58.101
+    PREFIX: "XF:31ID1-CT{IOC:GPIO1}"
+    ENGINEER: "H. Xu"    # Your name/contact info

--- a/roles/device_roles/elio/example.yml
+++ b/roles/device_roles/elio/example.yml
@@ -29,7 +29,6 @@ gpio_ex1:
   # PREFIX: used for IOC-specific PVs
   # HOST may be an IP address or host name
   # EK9K: port name
-  # NUM_TERMS: total terminal numbers
   environment:
     SYS: "XF:31ID1-ES"
     DEV: "GPIO:1"

--- a/roles/device_roles/elio/schema.yml
+++ b/roles/device_roles/elio/schema.yml
@@ -1,7 +1,7 @@
 ---
 
 type: enum("elio")
-terminals: list(include("terminal"))
+terminals: list(include("terminal"), min=1)
 environment:
   SYS: str()
   DEV: str()

--- a/roles/device_roles/elio/schema.yml
+++ b/roles/device_roles/elio/schema.yml
@@ -20,4 +20,4 @@ terminal:
   # Optional dict for channel-specific configuration,
   # e.g. {1: {"LINR": "SLOPE"}, 2: {"LINR": "SLOPE"}} for channels 1 and 2
   CHAN_SPECIFIC_CONFIG: >-
-    map(map(any(str(), num()), key=str()), key=int(), required=False)
+    map(map(any(str(), num()), key=str()), key=int(min=1), required=False)

--- a/roles/device_roles/elio/schema.yml
+++ b/roles/device_roles/elio/schema.yml
@@ -1,11 +1,23 @@
 ---
 
 type: enum("elio")
+terminals: list(include("terminal"))
 environment:
   SYS: str()
   DEV: str()
   EK9K: str()
   HOST: str()
-  NUM_TERMS: int()
   PREFIX: str()
   ENGINEER: str()
+
+---
+terminal:
+  POS: int(min=1)
+  MODEL: >-
+    enum("EL1124", "EL1808", "EL2124", "EL2798", "EL2808",
+    "EL3008", "EL3068", "EL3154", "EL3164", "EL3314",
+    "EL4008", "EL4038", "EL4104", "EL4134", "EL9505")
+  # Optional dict for channel-specific configuration,
+  # e.g. {1: {"LINR": "SLOPE"}, 2: {"LINR": "SLOPE"}} for channels 1 and 2
+  CHAN_SPECIFIC_CONFIG: >-
+    map(map(any(str(), num()), key=str()), key=int(), required=False)

--- a/roles/device_roles/elio/templates/base.cmd.j2
+++ b/roles/device_roles/elio/templates/base.cmd.j2
@@ -25,7 +25,7 @@ dbLoadTemplate("{{ deploy_ioc_template_root_path }}/db/$(MODEL).substitutions","
 {% for key, value in chan_config.items() %}
 {% set _ = chan_macros.append(key ~ "=" ~ value) %}
 {% endfor %}
-dbLoadTemplate("{{ deploy_ioc_template_root_path }}/db/$(MODEL).template","DEVICE=$(EK9K), Sys=$(SYS), Dev=$(Dev), POS=$(POS), CHAN={{ chan }}{% if chan_macros %}, {{ chan_macros | join(', ') }}{% endif %}")
+dbLoadRecords("{{ deploy_ioc_template_root_path }}/db/$(MODEL).template","DEVICE=$(EK9K), Sys=$(SYS), Dev=$(Dev), POS=$(POS), CHAN={{ chan }}{% if chan_macros %}, {{ chan_macros | join(', ') }}{% endif %}")
 {% endfor %}
 {% endif %}
 

--- a/roles/device_roles/elio/templates/base.cmd.j2
+++ b/roles/device_roles/elio/templates/base.cmd.j2
@@ -3,17 +3,29 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 {{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)
 
 # Configure the low level communication port
-ek9000Configure("${EK9K}", "${HOST}", 502, ${NUM_TERMS})
+ek9000Configure("${EK9K}", "${HOST}", 502, {{ ioc.terminals | length }})
 dbLoadRecords("{{ deploy_ioc_template_root_path }}/db/ek9000_status.db","P=$(SYS){$(DEV)},EK9K=$(EK9K)")
 
 # Configure terminal
 {% for elio in ioc.terminals %}
-############  Config for elio #{{ loop.index }} - {{ elio[0] }} - {{ elio[1] }}  ############
+{% set num_chans = elio.MODEL[-1] | int %}
+############  Config for elio #{{ loop.index }} - {{ elio.POS }} - {{ elio.MODEL }}  ############
 
-epicsEnvSet("POS",{{ elio[0] }})
-epicsEnvSet("MODEL","{{ elio[1] }}")
+epicsEnvSet("POS",{{ elio.POS }})
+epicsEnvSet("MODEL","{{ elio.MODEL }}")
 epicsEnvSet("Dev","{$(DEV)_$(POS)}")
 ek9000ConfigureTerminal("$(EK9K)", "$(Dev)", "$(MODEL)", "$(POS)")
+{% if elio.CHAN_SPECIFIC_CONFIG is not defined %}
 dbLoadTemplate("{{ deploy_ioc_template_root_path }}/db/$(MODEL).substitutions","DEVICE=$(EK9K), Sys=$(SYS), Dev=$(Dev), POS=$(POS)")
+{% else %}
+{% for chan in range(1, num_chans + 1) %}
+{% set chan_config = elio.CHAN_SPECIFIC_CONFIG[chan] if elio.CHAN_SPECIFIC_CONFIG is defined and chan in elio.CHAN_SPECIFIC_CONFIG else {} %}
+{% set chan_macros = [] %}
+{% for key, value in chan_config.items() %}
+{% if chan_macros.append(key ~ "=" ~ value) %}{% endif %}
+{% endfor %}
+dbLoadTemplate("{{ deploy_ioc_template_root_path }}/db/$(MODEL).template","DEVICE=$(EK9K), Sys=$(SYS), Dev=$(Dev), POS=$(POS), CHAN={{ chan }}{% if chan_macros %}, {{ chan_macros | join(', ') }}{% endif %}")
+{% endfor %}
+{% endif %}
 
 {% endfor %}

--- a/roles/device_roles/elio/templates/base.cmd.j2
+++ b/roles/device_roles/elio/templates/base.cmd.j2
@@ -8,6 +8,7 @@ dbLoadRecords("{{ deploy_ioc_template_root_path }}/db/ek9000_status.db","P=$(SYS
 
 # Configure terminal
 {% for elio in ioc.terminals %}
+{# The last character of the model name indicates the number of channels, e.g. EL3068 has 8 channels #}
 {% set num_chans = elio.MODEL[-1] | int %}
 ############  Config for elio #{{ loop.index }} - {{ elio.POS }} - {{ elio.MODEL }}  ############
 
@@ -22,7 +23,7 @@ dbLoadTemplate("{{ deploy_ioc_template_root_path }}/db/$(MODEL).substitutions","
 {% set chan_config = elio.CHAN_SPECIFIC_CONFIG[chan] if elio.CHAN_SPECIFIC_CONFIG is defined and chan in elio.CHAN_SPECIFIC_CONFIG else {} %}
 {% set chan_macros = [] %}
 {% for key, value in chan_config.items() %}
-{% if chan_macros.append(key ~ "=" ~ value) %}{% endif %}
+{% set _ = chan_macros.append(key ~ "=" ~ value) %}
 {% endfor %}
 dbLoadTemplate("{{ deploy_ioc_template_root_path }}/db/$(MODEL).template","DEVICE=$(EK9K), Sys=$(SYS), Dev=$(Dev), POS=$(POS), CHAN={{ chan }}{% if chan_macros %}, {{ chan_macros | join(', ') }}{% endif %}")
 {% endfor %}


### PR DESCRIPTION
Allows for specifying custom fields for specific channel's records.

Note: I slightly changed the schema, so any already deployed configurations in ioc_host_vars will need to be updated.
