### PR TITLE
Bump version of ADSupport, ADCore, ADEiger. Add support for Pilatus4 to ADEiger role

### DIFF
--- a/roles/deploy_ioc/vars/adeiger.yml
+++ b/roles/deploy_ioc/vars/adeiger.yml
@@ -2,7 +2,7 @@
 
 deploy_ioc_use_common: true
 deploy_ioc_use_ad_common: true
-deploy_ioc_required_module: adeiger_05e8a65
+deploy_ioc_required_module: adeiger_a7b25dc
 deploy_ioc_as_dir_name: autosave
 deploy_ioc_template_root_path:
   "{{ deploy_ioc_required_module_path }}/iocs/eigerIOC"

--- a/roles/device_roles/adeiger/example.yml
+++ b/roles/device_roles/adeiger/example.yml
@@ -3,7 +3,7 @@
 adeiger-01:
   type: adeiger
   # Eiger version must be 1 for Eiger or 2 for Eiger2
-  eiger_version: 1
+  detector_model: eiger1
 
   # Configure local port if Eiger is connected directly to the server.
   # Comment out otherwise.

--- a/roles/device_roles/adeiger/example.yml
+++ b/roles/device_roles/adeiger/example.yml
@@ -2,7 +2,7 @@
 
 adeiger-01:
   type: adeiger
-  # Eiger version must be 1 for Eiger or 2 for Eiger2
+  # Detector model must be one of the following: eiger1, eiger2, pilatus4, selun
   detector_model: eiger1
 
   # Configure local port if Eiger is connected directly to the server.
@@ -13,7 +13,7 @@ adeiger-01:
   environment:
     ENGINEER: C. Engineer
     PREFIX: XF:31ID1-ES{ADEIGER:01}
-    EIGER_IP: "10.69.57.71"
+    DCU_IP: "192.168.100.10"
 
     XSIZE: 1030
     YSIZE: 1065

--- a/roles/device_roles/adeiger/schema.yml
+++ b/roles/device_roles/adeiger/schema.yml
@@ -1,8 +1,8 @@
 ---
 
 type: enum("adeiger")
-# Eiger version must be 1 for Eiger or 2 for Eiger2
-eiger_version: enum(1, 2)
+
+detector_model: enum("eiger1", "eiger2", "pilatus4", "selun")
 
 # Configure local port if Eiger is connected directly to the server.
 # Comment out otherwise.

--- a/roles/device_roles/adeiger/schema.yml
+++ b/roles/device_roles/adeiger/schema.yml
@@ -12,7 +12,7 @@ adeiger_local_intf_ip: any(ip(), hostname(), required=False)
 environment:
   ENGINEER: str()
   PREFIX: str()
-  EIGER_IP: any(ip(), hostname())
+  DCU_IP: any(ip(), hostname())
   STREAM_IP: any(ip(), hostname(), required=False)
 
   XSIZE: int()

--- a/roles/device_roles/adeiger/templates/base.cmd.j2
+++ b/roles/device_roles/adeiger/templates/base.cmd.j2
@@ -10,7 +10,7 @@ eigerDetectorConfig("$(PORT)", "$(EIGER_IP)", "$(STREAMIP)", 0, 0)
 {% else %}
 eigerDetectorConfig("$(PORT)", "$(EIGER_IP)", 0, 0)
 {% endif %}
-dbLoadRecords("$(ADEIGER)/db/eiger{{ ioc.eiger_version }}.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
+dbLoadRecords("$(ADEIGER)/db/{{ ioc.detector_model }}.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
 
 
 # Debug

--- a/roles/device_roles/adeiger/templates/base.cmd.j2
+++ b/roles/device_roles/adeiger/templates/base.cmd.j2
@@ -5,10 +5,10 @@ dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable
 # adeiger specific commands
 errlogInit(20000)
 
-{% if ioc.environment.STREAMIP is defined %}
-eigerDetectorConfig("$(PORT)", "$(EIGER_IP)", "$(STREAMIP)", 0, 0)
+{% if ioc.environment.STREAM_IP is defined %}
+eigerDetectorConfig("$(PORT)", "$(DCU_IP)", "$(STREAM_IP)", 0, 0)
 {% else %}
-eigerDetectorConfig("$(PORT)", "$(EIGER_IP)", 0, 0)
+eigerDetectorConfig("$(PORT)", "$(DCU_IP)", 0, 0)
 {% endif %}
 dbLoadRecords("$(ADEIGER)/db/{{ ioc.detector_model }}.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
 

--- a/roles/install_module/vars/adandor3_1e33769.yml
+++ b/roles/install_module/vars/adandor3_1e33769.yml
@@ -7,7 +7,7 @@ adandor3_1e33769:
   include_base_ad_config: true
   executable: andor3App
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/adcompvision_9750d13.yml
+++ b/roles/install_module/vars/adcompvision_9750d13.yml
@@ -6,6 +6,6 @@ adcompvision_9750d13:
   include_base_ad_config: true
   version: 9750d13
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
   pkg_deps:
     - opencv-devel

--- a/roles/install_module/vars/adcore_5860bd3.yml
+++ b/roles/install_module/vars/adcore_5860bd3.yml
@@ -1,9 +1,8 @@
 ---
-
-adcore_60080dc:
+adcore_5860bd3:
   name: ADCore
   url: https://github.com/areaDetector/ADCore
   include_base_ad_config: true
-  version: 60080dc
+  version: 5860bd3
   module_deps:
     - adsupport_fe23754

--- a/roles/install_module/vars/adeiger_a7b25dc.yml
+++ b/roles/install_module/vars/adeiger_a7b25dc.yml
@@ -1,10 +1,9 @@
 ---
-
-adeiger_05e8a65:
+adeiger_a7b25dc:
   name: ADEiger
   url: https://github.com/areadetector/ADEiger
   include_base_ad_config: true
-  version: 05e8a65
+  version: a7b25dc
   executable: eigerDetectorApp
   module_deps:
     - adcore_5860bd3

--- a/roles/install_module/vars/adgenicam_5d08a11.yml
+++ b/roles/install_module/vars/adgenicam_5d08a11.yml
@@ -9,7 +9,7 @@ adgenicam_5d08a11:
     - python3.11 # Required for auto-generating database and bobfiles
   include_base_ad_config: true
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/adgermanium_0395fac.yml
+++ b/roles/install_module/vars/adgermanium_0395fac.yml
@@ -6,5 +6,5 @@ adgermanium_0395fac:
   url: https://github.com/lijibnl/test-deployment
   include_base_ad_config: true
   module_deps:
-    - adcore_60080dc
-    - adsupport_6acf83f
+    - adcore_5860bd3
+    - adsupport_fe23754

--- a/roles/install_module/vars/adkinetix_aa87406.yml
+++ b/roles/install_module/vars/adkinetix_aa87406.yml
@@ -7,7 +7,7 @@ adkinetix_aa87406:
   include_base_ad_config: true
   executable: kinetixApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/admerlin_f9b6b1b.yml
+++ b/roles/install_module/vars/admerlin_f9b6b1b.yml
@@ -7,7 +7,7 @@ admerlin_f9b6b1b:
   version: f9b6b1b
   executable: merlinApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/admythen_bcf2947.yml
+++ b/roles/install_module/vars/admythen_bcf2947.yml
@@ -7,7 +7,7 @@ admythen_bcf2947:
   include_base_ad_config: true
   executable: mythenApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/adpco_b17fe13.yml
+++ b/roles/install_module/vars/adpco_b17fe13.yml
@@ -12,4 +12,4 @@ adpco_b17fe13:
     PCO_LIB: "$(PCO_SDK)/lib"
     PCO_INCLUDE: "$(PCO_SDK)/include"
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/adphantom_afefafc.yml
+++ b/roles/install_module/vars/adphantom_afefafc.yml
@@ -6,6 +6,6 @@ adphantom_afefafc:
   url: https://github.com/jwlodek/ADPhantom
   include_base_ad_config: true
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
   pkg_deps:
     - libpcap-devel

--- a/roles/install_module/vars/adpicam_0d86fae.yml
+++ b/roles/install_module/vars/adpicam_0d86fae.yml
@@ -7,7 +7,7 @@ adpicam_0d86fae:
   include_base_ad_config: true
   executable: ADPICamApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/adpilatus_72c7844.yml
+++ b/roles/install_module/vars/adpilatus_72c7844.yml
@@ -6,7 +6,7 @@ adpilatus_72c7844:
   include_base_ad_config: true
   executable: pilatusDetectorApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/adpluginbar_448d96b.yml
+++ b/roles/install_module/vars/adpluginbar_448d96b.yml
@@ -6,6 +6,6 @@ adpluginbar_448d96b:
   url: https://github.com/areaDetector/ADPluginBar
   include_base_ad_config: true
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
   pkg_deps:
     - zbar-devel

--- a/roles/install_module/vars/adprosilica_9abb772.yml
+++ b/roles/install_module/vars/adprosilica_9abb772.yml
@@ -7,4 +7,4 @@ adprosilica_9abb772:
   include_base_ad_config: true
   version: 9abb772
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/adscanpb_f54e2c1.yml
+++ b/roles/install_module/vars/adscanpb_f54e2c1.yml
@@ -7,4 +7,4 @@ adscanpb_f54e2c1:
   include_base_ad_config: true
   executable: scanPBApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/adsimdetector_4b236f4.yml
+++ b/roles/install_module/vars/adsimdetector_4b236f4.yml
@@ -13,7 +13,7 @@ adsimdetector_4b236f4:
   version: 4b236f4
   include_base_ad_config: true
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/adsupport_fe23754.yml
+++ b/roles/install_module/vars/adsupport_fe23754.yml
@@ -1,0 +1,11 @@
+---
+adsupport_fe23754:
+  name: ADSupport
+  url: https://github.com/areaDetector/ADSupport
+  include_base_ad_config: true
+  version: fe23754
+  pkg_deps:
+    - libxml2-devel
+    - libXext-devel
+    - zlib-devel
+    - libX11-devel

--- a/roles/install_module/vars/adtimepix3_2faf970.yml
+++ b/roles/install_module/vars/adtimepix3_2faf970.yml
@@ -9,5 +9,5 @@ adtimepix3_2faf970:
   pkg_deps:
     - curl-devel
   module_deps:
-    - adcore_60080dc
-    - adsupport_6acf83f
+    - adcore_5860bd3
+    - adsupport_fe23754

--- a/roles/install_module/vars/adtucam_c8c1685.yml
+++ b/roles/install_module/vars/adtucam_c8c1685.yml
@@ -6,4 +6,4 @@ adtucam_c8c1685:
   version: c8c1685
   executable: tucamApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/adurl_1c725ed.yml
+++ b/roles/install_module/vars/adurl_1c725ed.yml
@@ -6,8 +6,8 @@ adurl_1c725ed:
   url: https://github.com/areaDetector/ADURL
   include_base_ad_config: true
   module_deps:
-    - adsupport_6acf83f
+    - adsupport_fe23754
     - adcompvision_9750d13
-    - adcore_60080dc
+    - adcore_5860bd3
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/aduvc_86918b6.yml
+++ b/roles/install_module/vars/aduvc_86918b6.yml
@@ -6,7 +6,7 @@ aduvc_86918b6:
   include_base_ad_config: true
   executable: uvcApp
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3
     - adcompvision_9750d13
     - adpluginbar_448d96b
     - ffmpeg_server_07c570f

--- a/roles/install_module/vars/adxspd_986de77.yml
+++ b/roles/install_module/vars/adxspd_986de77.yml
@@ -10,4 +10,4 @@ adxspd_986de77:
     - curl-devel
   module_deps:
     - adcompvision_9750d13
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/ffmpeg_server_07c570f.yml
+++ b/roles/install_module/vars/ffmpeg_server_07c570f.yml
@@ -6,4 +6,4 @@ ffmpeg_server_07c570f:
   compilation_command: "bash install.sh" # ffmpegServer builds custom script
   include_base_ad_config: true
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/quadem_f5ab1e9.yml
+++ b/roles/install_module/vars/quadem_f5ab1e9.yml
@@ -10,4 +10,4 @@ quadem_f5ab1e9:
   compilation_command:
     "cp quadEMApp/src/drvQuadEM.h quadEMApp/sydorSrc && make -sj"
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/xspress3_5f459a1.yml
+++ b/roles/install_module/vars/xspress3_5f459a1.yml
@@ -6,4 +6,4 @@ xspress3_5f459a1:
   include_base_ad_config: true
   overwrite_config_site: true
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3


### PR DESCRIPTION
Newer versions of ADSupport, ADCore, and ADEiger are requried to allow for fixed compression settings for the stream2 interface. Pilatus4 detectors use the same API as Eigers, and so use the ADEiger IOC.
