### PR TITLE
Add xspress3 driver 3_2_8 for classic xspress3

### DIFF
--- a/roles/install_module/vars/xspress3_82eae5a.yml
+++ b/roles/install_module/vars/xspress3_82eae5a.yml
@@ -5,4 +5,4 @@ xspress3_82eae5a:
   url: https://github.com/epics-modules/xspress3
   include_base_ad_config: true
   module_deps:
-    - adcore_60080dc
+    - adcore_5860bd3

--- a/roles/install_module/vars/xspress3_82eae5a.yml
+++ b/roles/install_module/vars/xspress3_82eae5a.yml
@@ -1,0 +1,8 @@
+---
+xspress3_82eae5a:
+  name: xspress3
+  version: 82eae5a
+  url: https://github.com/epics-modules/xspress3
+  include_base_ad_config: true
+  module_deps:
+    - adcore_60080dc


### PR DESCRIPTION
Classic xspress3 modules are not supported in the most recent drivers. This PR adds an option to use community driver v3.2.8.