### PR TITLE
Add adkreios device role for SPECS KREIOS-150 areaDetector IOC

### DIFF
--- a/roles/deploy_ioc/vars/adkreios.yml
+++ b/roles/deploy_ioc/vars/adkreios.yml
@@ -1,0 +1,27 @@
+---
+
+deploy_ioc_required_module: adkreios_4ec03dc
+deploy_ioc_template_root_path:
+  "{{ deploy_ioc_required_module_path }}/iocs/kreiosIOC"
+
+# ADKreios is an areaDetector driver, so load the standard AD plugin stack
+# (commonPlugins.cmd, autosave, reccaster, iocStats) via the shared common.cmd.
+deploy_ioc_use_ad_common: true
+
+deploy_ioc_req_file_list:
+  - name: auto_settings.req
+    macros: "P=$(PREFIX)"
+
+deploy_ioc_device_specific_env:
+  PORT: "KREIOS1"
+  QSIZE: 20
+  NCHANS: 2048
+  CBUFFS: 500
+  MAX_THREADS: 8
+  # KREIOS-150 detector dimensions (overridable per instance)
+  XSIZE: 1285
+  YSIZE: 730
+  NELEMENTS: 50000000
+  # SpecsLab Prodigy "Remote In" server (override PRODIGY_HOST per instance)
+  PRODIGY_HOST: "127.0.0.1"
+  PRODIGY_PORT: 7010

--- a/roles/device_roles/adkreios/examples/kreios-det1/config.yml
+++ b/roles/device_roles/adkreios/examples/kreios-det1/config.yml
@@ -1,0 +1,12 @@
+---
+
+kreios-det1:
+  type: "adkreios"
+
+  environment:
+    PREFIX: "XF:29ID2-ES{Det:Kreios}:"
+    ENGINEER: "A. Sligar"
+    PRODIGY_HOST: "xf29id2-kreios1.nsls2.bnl.local"
+    PRODIGY_PORT: 7010
+    XSIZE: 1285
+    YSIZE: 730

--- a/roles/device_roles/adkreios/examples/kreios-det1/verify.yml
+++ b/roles/device_roles/adkreios/examples/kreios-det1/verify.yml
@@ -1,0 +1,43 @@
+---
+# Set to true to skip module compilation. ADKreios only needs open-source EPICS
+# modules (ADCore/ADSupport + the epics-bundle), so compilation can run in CI.
+skip_compilation: false
+
+verification:
+  files_must_exist:
+    # Standard IOC boot files (created by deploy_ioc)
+    - iocBoot/st.cmd
+    - iocBoot/epicsEnv.cmd
+    - iocBoot/postInit.cmd
+    # Role-specific files
+    - iocBoot/base.cmd
+    - as/req/auto_settings.req
+
+  file_must_contain:
+    iocBoot/st.cmd:
+      - "iocInit"
+    iocBoot/base.cmd:
+      - "dbLoadDatabase"
+      - "drvAsynIPPortConfigure"
+      - "kreiosConfig"
+      - 'dbLoadRecords("$(ADKREIOS)/db/kreios.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")' # yamllint disable-line rule:line-length
+    as/req/auto_settings.req:
+      - "kreios_settings.req"
+      - "commonPlugin_settings.req"
+
+  file_must_not_contain:
+    iocBoot/st.cmd:
+      - "{{"  # No unrendered jinja
+      - "}}"
+    iocBoot/base.cmd:
+      - "{{"
+      - "}}"
+    iocBoot/epicsEnv.cmd:
+      - "{{"
+      - "}}"
+    as/req/auto_settings.req:
+      - "{{"
+      - "}}"
+
+  permissions:
+    iocBoot/st.cmd: "0775"

--- a/roles/device_roles/adkreios/schema.yml
+++ b/roles/device_roles/adkreios/schema.yml
@@ -1,0 +1,18 @@
+---
+type: enum("adkreios")
+
+environment:
+  PREFIX: str()  # Base PV prefix
+  ENGINEER: str(required=False)  # Responsible engineer
+
+  # SpecsLab Prodigy "Remote In" server connection (TCP, default port 7010)
+  PRODIGY_HOST: str()  # Hostname/IP of the machine running SpecsLab Prodigy
+  PRODIGY_PORT: int(min=1, max=65535, required=False)  # Prodigy TCP port
+
+  # KREIOS-150 detector image size in pixels/channels
+  XSIZE: int(min=1, required=False)
+  YSIZE: int(min=1, required=False)
+
+  PORT: str(required=False)  # Optional asyn port name for the driver
+  QSIZE: int(min=1, required=False)  # Optional plugin queue size
+  MAX_THREADS: int(min=1, required=False)  # Optional max plugin threads

--- a/roles/device_roles/adkreios/tasks/main.yml
+++ b/roles/device_roles/adkreios/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Copy base.cmd
+  ansible.builtin.template:
+    src: "templates/base.cmd.j2"
+    dest: "{{ deploy_ioc_ioc_directory }}/iocBoot/base.cmd"
+    owner: "{{ host_config.softioc_user }}"
+    group: "{{ host_config.softioc_group }}"
+    mode: "0664"
+
+- name: Copy autosave req file
+  ansible.builtin.template:
+    src: "templates/auto_settings.req.j2"
+    dest: "{{ deploy_ioc_as_directory }}/req/auto_settings.req"
+    owner: "{{ host_config.softioc_user }}"
+    group: "{{ host_config.softioc_group }}"
+    mode: "0664"

--- a/roles/device_roles/adkreios/templates/auto_settings.req.j2
+++ b/roles/device_roles/adkreios/templates/auto_settings.req.j2
@@ -1,0 +1,2 @@
+file "kreios_settings.req",               P=$(P),  R=cam1:
+file "commonPlugin_settings.req",         P=$(P)

--- a/roles/device_roles/adkreios/templates/base.cmd.j2
+++ b/roles/device_roles/adkreios/templates/base.cmd.j2
@@ -1,0 +1,19 @@
+dbLoadDatabase("{{ deploy_ioc_template_root_path }}/dbd/{{ deploy_ioc_executable }}.dbd")
+{{ deploy_ioc_executable }}_registerRecordDeviceDriver(pdbbase)
+
+# Asyn IP port for the SpecsLab Prodigy "Remote In" TCP server (default port 7010)
+drvAsynIPPortConfigure("PRODIGY", "$(PRODIGY_HOST):$(PRODIGY_PORT)", 0, 0, 0)
+asynSetTraceIOMask("PRODIGY", 0, 2)
+
+# KREIOS-150 driver:
+# kreiosConfig(portName, driverPort, maxBuffers, maxMemory, priority, stackSize)
+kreiosConfig("$(PORT)", "PRODIGY", 0, 0, 0, 0)
+
+# Give the driver a moment to establish the Prodigy connection
+epicsThreadSleep(2)
+
+# Main detector database
+dbLoadRecords("$(ADKREIOS)/db/kreios.template", "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1")
+
+# Make the KREIOS autosave request files discoverable
+set_requestfile_path("$(ADKREIOS)/db")

--- a/roles/install_module/vars/adkreios_4ec03dc.yml
+++ b/roles/install_module/vars/adkreios_4ec03dc.yml
@@ -1,0 +1,18 @@
+---
+
+adkreios_4ec03dc:
+  name: ADKreios
+  url: https://github.com/NSLS2/ADKreios
+  version: 4ec03dc
+
+  # ADKreios is an areaDetector driver, so pull in the standard AD build config
+  # (HDF5, TIFF, JPEG, etc.) and let deploy overwrite CONFIG_SITE/RELEASE.
+  include_base_ad_config: true
+
+  # Name of the example IOC application/executable built under iocs/kreiosIOC.
+  executable: kreios
+
+  # ADCore transitively provides ADSupport. asyn, autosave, busy, calc, sscan,
+  # seq and iocStats come from the epics-bundle (see install_module defaults).
+  module_deps:
+    - adcore_60080dc


### PR DESCRIPTION
## Summary

Adds a device role to deploy the **ADKreios** areaDetector driver, which controls the SPECS KREIOS-150 momentum microscope over the SpecsLab Prodigy "Remote In" TCP protocol (v1.22, default port 7010).

Module source: https://github.com/NSLS2/ADKreios (example IOC executable `kreios`, depends on ADCore).

## Changes

- `roles/install_module/vars/adkreios_4ec03dc.yml` — builds the ADKreios module (standard areaDetector build config; ADCore as the module dependency).
- `roles/device_roles/adkreios/` — `schema.yml`, `tasks/main.yml`, `base.cmd`/`auto_settings.req` templates, and an example config + `verify.yml`.
- `roles/deploy_ioc/vars/adkreios.yml` — device defaults (uses the AD common plugin stack; `PRODIGY_HOST`/`PRODIGY_PORT` for the analyzer server).

## Configuration

The IOC connects to a SpecsLab Prodigy server via an asyn IP port (`PRODIGY_HOST:PRODIGY_PORT`). Detector image size is set with `XSIZE`/`YSIZE` (default 1285×730). See `roles/device_roles/adkreios/schema.yml` for the full schema and `examples/kreios-det1/` for a working example.

## Testing

- `pytest` (schema, vars, example, and verify validation): all pass.
- Local container deploy (`pixi run deployment --container -t adkreios`, EL8): builds ADCore + ADKreios, deploys the example IOC, and all `verify.yml` checks pass.

## Note for maintainers

The module repository `NSLS2/ADKreios` is currently internal. The `install_module` clone step (and CI) requires it to be anonymously cloneable, so it will need to be made public before automated deployment/CI can build it.