### PR TITLE
add --not-reinstall-collections for quicker deployment

### DIFF
--- a/scripts/deploy_local_config.py
+++ b/scripts/deploy_local_config.py
@@ -164,7 +164,16 @@ def install_galaxy_collection(
 
 
 def install_local_collection(top_path: Path, reinstall_collection: bool = True):
+    local_collection_path = (
+        top_path / "collections" / "ansible_collections" / "nsls2" / "ioc_deploy"
+    )
+
     if not reinstall_collection:
+        if not local_collection_path.exists():
+            logger.warning("Local Galaxy collections are missing, installing them ...")
+            install_galaxy_collection(str(top_path), force=True)
+            return
+
         logger.info(
             "Skipping local collection reinstall/rebuild per "
             "--not-reinstall-collections"

--- a/scripts/deploy_local_config.py
+++ b/scripts/deploy_local_config.py
@@ -163,6 +163,17 @@ def install_galaxy_collection(
         raise RuntimeError(f"Failed to install galaxy collection {name}: {e}") from e
 
 
+def install_local_collection(top_path: Path, reinstall_collection: bool = True):
+    if not reinstall_collection:
+        logger.info(
+            "Skipping local collection reinstall/rebuild per "
+            "--not-reinstall-collections"
+        )
+        return
+
+    install_galaxy_collection(str(top_path), force=True)
+
+
 @dataclass
 class DeploymentOptions:
     hostname: str
@@ -366,6 +377,14 @@ def main():
         default="pixi",
         help="Path to the pixi executable (default: 'pixi' - i.e. must be in PATH)",
     )
+    parser.add_argument(
+        "--not-reinstall-collections",
+        action="store_true",
+        help=(
+            "Skip reinstall/rebuild of the local nsls2.ioc_deploy collection before "
+            "deployment"
+        ),
+    )
 
     example_source_group = parser.add_mutually_exclusive_group()
     example_source_group.add_argument("-t", "--type", help="Type of IOC to deploy")
@@ -430,7 +449,9 @@ def main():
             )
             break
 
-    install_galaxy_collection(str(top_path), force=True)
+    install_local_collection(
+        top_path, reinstall_collection=not args.not_reinstall_collections
+    )
 
     if args.all:
         logger.info("Finding all examples for all IOC types")


### PR DESCRIPTION
An improvement for [issue #275](https://github.com/NSLS2/nsls2.ioc_deploy/issues/275). 
By default, `pixi run deployment -l ioc_full_host_name -c ../ioc_host_vars/acc_or_xf/ioc_full_host_name/ioc_instance_name.yml` still re-installs the latest Galaxy collections by the command `ansible-galaxy collection install ...`, that takes more than 90 seconds, the majority  of deployment time. For a quicker testing, one can use the option `--not-reinstall-collections` to skip the re-installation of the Galaxy collections if he/she is pretty sure the collections are already up-to-date.      

