### PR TITLE
Change powerpmac schema to 16 axes

### DIFF
--- a/roles/device_roles/powerpmac/schema.yml
+++ b/roles/device_roles/powerpmac/schema.yml
@@ -6,7 +6,7 @@ environment:
   CONTROLLER: str()
   DEV: str()
   CT_SYS: str()
-  NUM_AXES: int(min=1, max=8)
+  NUM_AXES: int(min=1, max=16)
   MOVING_POLL_PERIOD: int(required=False)
   IDLE_POLL_PERIOD: int(required=False)
   CONTROLLER_IP: any(ip(), hostname())
@@ -14,7 +14,7 @@ environment:
 disable_all_limits: bool(required=False)
 
 coord_systems: list(include("coord_system"), required=False)
-axes: list(include("axis"), min=1, max=8, required=False)
+axes: list(include("axis"), min=1, max=16, required=False)
 virtual_axes: list(include("virtual_axis"), required=False)
 poll_periods: list(include("poll_period"), required=False)
 
@@ -27,7 +27,7 @@ coord_system:
 
 axis:
   name: str()
-  num: int(min=1, max=8)
+  num: int(min=1, max=16)
   component: str()
   desc: str()
   mres: num()
@@ -36,7 +36,7 @@ axis:
 
 virtual_axis:
   name: str()
-  num: int(min=1, max=8)
+  num: int(min=1, max=16)
   cs: int()
   component: str()
   desc: str()


### PR DESCRIPTION
Sometimes we use encoder readbacks on axes 9-16.  The full motor record may be overkill, but otherwise we need to put in MRES and offsets potentially in standalone PVs.